### PR TITLE
Fixed negative cell index inputs

### DIFF
--- a/src/commands/execute_cell.rs
+++ b/src/commands/execute_cell.rs
@@ -12,7 +12,7 @@ pub struct ExecuteCellArgs {
     pub file: String,
 
     /// Cell index to execute (supports negative indexing like -1 for last cell)
-    #[arg(short, long, group = "cell_selector")]
+    #[arg(short, long, group = "cell_selector", allow_negative_numbers = true)]
     pub cell: Option<i32>,
 
     /// Cell ID to execute

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::process;
 #[derive(Parser)]
 #[command(name = "nb")]
 #[command(about = "CLI tool for working with Jupyter notebooks", version)]
+#[command(allow_negative_numbers = true)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -335,6 +335,47 @@ fn test_execute_with_timeout() {
 }
 
 #[test]
+fn test_execute_last_cell_with_negative_index() {
+    let Some(env) = TestEnv::new() else {
+        eprintln!("⚠️  Skipping test: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.notebook_path("test.ipynb");
+
+    // Create a notebook with independent cells
+    env.run(&["notebook", "create", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    env.run(&[
+        "cell",
+        "add",
+        nb_path.to_str().unwrap(),
+        "--source",
+        "x = 10",
+    ])
+    .assert_success();
+
+    env.run(&[
+        "cell",
+        "add",
+        nb_path.to_str().unwrap(),
+        "--source",
+        "result = 2 + 2",
+    ])
+    .assert_success();
+
+    // Execute last cell using -c -1 (space-separated style)
+    // This tests that allow_negative_numbers is properly configured
+    let result = env
+        .run(&["cell", "execute", nb_path.to_str().unwrap(), "-c", "-1"])
+        .assert_success();
+
+    assert!(result.contains("executed") || result.contains("success"));
+    assert!(result.contains("Cell index: 1"));
+}
+
+#[test]
 fn test_execute_dry_run() {
     let Some(env) = TestEnv::new() else {
         eprintln!("⚠️  Skipping test: execution environment not available");

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -79,11 +79,6 @@ fn initialize_venv() -> Option<PathBuf> {
     }
 }
 
-/// Check if execution tests can run
-pub fn can_run_execution_tests() -> bool {
-    setup_execution_venv().is_some()
-}
-
 /// Set environment to use test venv for execution
 pub fn setup_venv_environment() -> Option<String> {
     let mutex = VENV_PATH.get()?;


### PR DESCRIPTION
## Summary
Fixes a bug where negative cell indices (e.g., -1 for last cell) were incorrectly parsed as flags instead of negative numbers. While negative indexing was documented and implemented in the code logic, the CLI argument parser wasn't configured to accept negative numbers, causing commands like `nb cell execute notebook.ipynb -c -1` to fail.

Both of these forms work after the fix:

```bash
nb cell execute notebook.ipynb -c -1

# Or
nb cell execute notebook.ipynb -c=-1
```

## Testing
Verified manually that both forms work after the fix. Also, added integration tests to verify the fix.