### PR TITLE
Fixed negative index parsing for all commands, updated tests

### DIFF
--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -26,7 +26,7 @@ pub struct AddCellArgs {
     pub source: String,
 
     /// Insert at index (supports negative, default: append)
-    #[arg(short = 'i', long = "insert-at", value_name = "INDEX", conflicts_with_all = ["after", "before"])]
+    #[arg(short = 'i', long = "insert-at", value_name = "INDEX", allow_negative_numbers = true, conflicts_with_all = ["after", "before"])]
     pub insert_at: Option<i32>,
 
     /// Insert after cell with ID

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -22,7 +22,7 @@ pub struct ClearOutputsArgs {
     pub cell: Option<String>,
 
     /// Clear specific cell by index (supports negative indexing)
-    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", conflicts_with_all = ["cell", "all"])]
+    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", allow_negative_numbers = true, conflicts_with_all = ["cell", "all"])]
     pub cell_index: Option<i32>,
 
     /// Clear all code cell outputs (default if no options)

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -22,7 +22,7 @@ pub struct DeleteCellArgs {
     pub cell: Vec<String>,
 
     /// Cell index(es) to delete (supports negative indexing)
-    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", conflicts_with_all = ["cell", "range"])]
+    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", allow_negative_numbers = true, conflicts_with_all = ["cell", "range"])]
     pub cell_index: Vec<i32>,
 
     /// Delete range [start, end) (exclusive end)

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -34,11 +34,11 @@ pub struct ExecuteNotebookArgs {
     pub cell_index: Option<i32>,
 
     /// Start cell index (inclusive)
-    #[arg(long, conflicts_with_all = ["cell", "cell_index"])]
+    #[arg(long, allow_negative_numbers = true, conflicts_with_all = ["cell", "cell_index"])]
     pub start: Option<i32>,
 
     /// End cell index (inclusive)
-    #[arg(long, conflicts_with_all = ["cell", "cell_index"])]
+    #[arg(long, allow_negative_numbers = true, conflicts_with_all = ["cell", "cell_index"])]
     pub end: Option<i32>,
 
     /// Remote server URL (enables remote mode)

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -27,7 +27,7 @@ pub struct ReadArgs {
     pub cell: Option<String>,
 
     /// Get specific cell by index (supports negative indexing like -1)
-    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", conflicts_with_all = ["cell", "only_code", "only_markdown"])]
+    #[arg(short = 'i', long = "cell-index", value_name = "INDEX", allow_negative_numbers = true, conflicts_with_all = ["cell", "only_code", "only_markdown"])]
     pub cell_index: Option<i32>,
 
     /// Include cell execution outputs in the display

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -24,6 +24,7 @@ pub struct UpdateCellArgs {
         short = 'i',
         long = "cell-index",
         value_name = "INDEX",
+        allow_negative_numbers = true,
         conflicts_with = "cell"
     )]
     pub cell_index: Option<i32>,

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -280,7 +280,7 @@ fn test_read_last_cell_negative_index() {
     let nb_path = env.copy_fixture("with_code.ipynb", "test.ipynb");
 
     let result = env
-        .run(&["read", nb_path.to_str().unwrap(), "--cell-index=-1"])
+        .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "-1"])
         .assert_success();
 
     let json = result.json_value();
@@ -528,7 +528,8 @@ fn test_add_cell_with_negative_index() {
             nb_path.to_str().unwrap(),
             "--source",
             "before last",
-            "--insert-at=-1",
+            "--insert-at",
+            "-1",
         ])
         .assert_success();
 
@@ -743,14 +744,15 @@ fn test_update_cell_negative_index() {
         "cell",
         "update",
         nb_path.to_str().unwrap(),
-        "--cell-index=-1",
+        "--cell-index",
+        "-1",
         "--source",
         "updated last cell",
     ])
     .assert_success();
 
     let result = env
-        .run(&["read", nb_path.to_str().unwrap(), "--cell-index=-1"])
+        .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "-1"])
         .assert_success();
     let json = result.json_value();
     let source = join_source(&json["source"]);
@@ -821,7 +823,7 @@ fn test_delete_with_negative_index() {
     let nb_path = env.copy_fixture("with_code.ipynb", "test.ipynb");
 
     let result = env
-        .run(&["cell", "delete", nb_path.to_str().unwrap(), "--cell-index=-1"])
+        .run(&["cell", "delete", nb_path.to_str().unwrap(), "--cell-index", "-1"])
         .assert_success();
 
     let json = result.json_value();
@@ -964,6 +966,19 @@ fn test_clear_outputs_specific_cell() {
 
     let result = env
         .run(&["output", "clear", nb_path.to_str().unwrap(), "--cell-index", "0"])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_cleared"], 1);
+}
+
+#[test]
+fn test_clear_outputs_negative_index() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("with_outputs.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&["output", "clear", nb_path.to_str().unwrap(), "--cell-index", "-1"])
         .assert_success();
 
     let json = result.json_value();


### PR DESCRIPTION
Fixes negative cell index parsing (`-1`, `-2`, etc.) for all commands that accept index arguments. PRs #1 and #3 fixed this for `execute`. This PR completes the rollout across the remaining commands.

Existing tests used `=` syntax (`--cell-index=-1`) which bypasses the bug as clap treats that as a single token. The space-separated form (`--cell-index -1`) is what actually fails without the attribute. Updated all existing negative index tests to use space-separated syntax so they guard against this regression.

### Changes

Added `allow_negative_numbers = true` to clap `#[arg]` annotations on:
- `read --cell-index`
- `cell update --cell-index`
- `cell delete --cell-index`
- `cell add --insert-at`
- `output clear --cell-index`
- `execute --start` / `--end`

### Testing

- Updated 4 existing negative index tests to use space-separated args
- Added `test_clear_outputs_negative_index` 