### PR TITLE
Preserve multi-line formatting when reading cells

### DIFF
--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -296,8 +296,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
 
                     // Sync changes to server
                     match ydoc_client.sync().await {
-                        Ok(_) => {
-                        }
+                        Ok(_) => {}
                         Err(e) => {
                             eprintln!("  Warning: Failed to sync Y.js updates: {}", e);
                         }

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -460,12 +460,6 @@ fn output_notebook_structure(
             println!("\nCells:");
             for (index, cell) in notebook.cells.iter().enumerate() {
                 let source = common::cell_to_string(cell);
-                let preview = if source.len() > 80 {
-                    format!("{}...", &source[..77])
-                } else {
-                    source
-                }
-                .replace('\n', " ");
 
                 let (cell_type, executed) = match cell {
                     Cell::Code {
@@ -482,13 +476,18 @@ fn output_notebook_structure(
                 };
 
                 println!(
-                    "  {} [{}]{} (ID: {}): {}",
+                    "  {} [{}]{} (ID: {}):",
                     index,
                     cell_type,
                     executed_marker,
                     common::cell_id_to_string(cell),
-                    preview
                 );
+
+                // Indent cell content for better readability
+                for line in source.lines() {
+                    println!("    {}", line);
+                }
+                println!();
             }
         }
     }

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -167,7 +167,7 @@ fn test_execute_cell_with_output() {
         ])
         .assert_success();
 
-    assert!(result.stdout.contains("outputs"));
+    assert!(result.stdout.contains("Outputs:") || result.stdout.contains("outputs"));
 }
 
 #[test]
@@ -236,8 +236,8 @@ fn test_execute_entire_notebook() {
         .run(&["read", nb_path.to_str().unwrap()])
         .assert_success();
 
-    // Check that execution counts were set
-    assert!(read_result.stdout.contains("execution_count"));
+    // Check that execution counts were set (shown by [✓] marker)
+    assert!(read_result.stdout.contains("[✓]"));
 }
 
 #[test]
@@ -295,7 +295,10 @@ fn test_execute_with_allow_errors() {
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "0"])
         .assert_success();
 
-    assert!(read_result.stdout.contains("execution_count"));
+    assert!(
+        read_result.stdout.contains("Execution count:")
+            || read_result.stdout.contains("execution_count")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #18

### BEFORE:

```
Notebook Structure
==================
Total cells: 7
Code cells: 4
Markdown cells: 3
Kernel: python3

Cells:
  0 [markdown] (ID: intro-cell): # Data Analysis Example  This notebook demonstrates basic data analysis opera...
  ...
  3 [code] [✓] (ID: create-data): df = pd.DataFrame({     'a': [1, 2, 3],     'b': [4, 5, 6],     'c': [7, 8, 9...
  4 [code] [ ] (ID: compute-stats): print("Mean values:") print(df.mean())
  ...
```

### After (multi-line formatting preserved):

```
Notebook Structure
==================
Total cells: 7
Code cells: 4
Markdown cells: 3
Kernel: python3

Cells:
  0 [markdown] (ID: intro-cell):
    # Data Analysis Example

  This notebook demonstrates basic data analysis operations.

  ...

  3 [code] [✓] (ID: create-data):
    df = pd.DataFrame({
        'a': [1, 2, 3],
        'b': [4, 5, 6],
        'c': [7, 8, 9]
    })
    df

  4 [code] [ ] (ID: compute-stats):
    print("Mean values:")
    print(df.mean())

  ...
```