### PR TITLE
Clean up duplicate `OutputFormat` enum and leftover status messages

### DIFF
--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -1,3 +1,4 @@
+use crate::commands::common::OutputFormat;
 use crate::execution::remote::ydoc::YDocClient;
 use crate::execution::{create_backend, types::ExecutionConfig, types::ExecutionMode};
 use crate::notebook::{read_notebook, write_notebook_atomic};
@@ -52,24 +53,6 @@ pub struct ExecuteNotebookArgs {
     /// Output in JSON format instead of text
     #[arg(long)]
     pub json: bool,
-}
-
-#[derive(Clone, Debug)]
-pub enum OutputFormat {
-    Json,
-    Text,
-}
-
-impl std::str::FromStr for OutputFormat {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s.to_lowercase().as_str() {
-            "json" => Ok(OutputFormat::Json),
-            "text" => Ok(OutputFormat::Text),
-            _ => anyhow::bail!("Invalid format: '{}'. Must be 'json' or 'text'", s),
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -118,19 +118,14 @@ async fn execute_with_realtime(
         .and_then(|n| n.to_str())
         .context("Invalid notebook path")?;
 
-    eprintln!("Checking if notebook is open in JupyterLab...");
-
     // Check if notebook has an active session
     let has_session = session_check::has_active_session(&server_url, &token, notebook_filename)
         .await
         .unwrap_or(false);
 
     if !has_session {
-        eprintln!("Notebook is not open - using file-based update");
         return execute_file_based(args);
     }
-
-    eprintln!("Notebook is open - using real-time Y.js updates");
 
     // Read notebook to find the cell
     let notebook = notebook::read_notebook(&args.file).context("Failed to read notebook")?;


### PR DESCRIPTION
Follow-up addressing https://github.com/jupyter-ai-contrib/nb-cli/pull/17#discussion_r2950027915 and https://github.com/jupyter-ai-contrib/nb-cli/pull/20#pullrequestreview-3964308266:
- Remove duplicate `OutputFormat` enum and dead `FromStr` impl from `execute_notebook.rs`. `OutputFormat` is now imported from `common.rs` like other commands
- Remove 3 session-check status messages from `update_cell.rs` that were already removed from `add_cell.rs` in PR 20