### PR TITLE
Fix cell count display in remote mode and rename Position to Index

### DIFF
--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -196,7 +196,7 @@ async fn execute_with_realtime(
         cell_type: cell_type_str.to_string(),
         cell_id: cell_id.to_string(),
         index: insert_index,
-        total_cells: notebook.cells.len(),
+        total_cells: notebook.cells.len() + 1,
     };
 
     let format = if args.json {
@@ -347,7 +347,7 @@ fn output_result(result: &AddCellResult, format: &OutputFormat) -> Result<()> {
             println!("Added {} cell to: {}", result.cell_type, result.file);
             println!("Cell ID: {}", result.cell_id);
             println!(
-                "Position: {} (total: {} cells)",
+                "Index: {} (total: {} cells)",
                 result.index, result.total_cells
             );
         }

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -654,6 +654,58 @@ fn test_add_cell_empty_source() {
     assert_eq!(json["index"], 0);
 }
 
+#[test]
+fn test_add_consecutive_cells_correct_count() {
+    // Regression test for issue #24 - cell count should be correct after each addition
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    // First cell
+    let result1 = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "--source",
+            "a = 10",
+            "--json",
+        ])
+        .assert_success();
+    let json1 = result1.json_value();
+    assert_eq!(json1["index"], 0);
+    assert_eq!(json1["total_cells"], 1);
+
+    // Second cell
+    let result2 = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "--source",
+            "b = 20",
+            "--json",
+        ])
+        .assert_success();
+    let json2 = result2.json_value();
+    assert_eq!(json2["index"], 1);
+    assert_eq!(json2["total_cells"], 2);
+
+    // Third cell
+    let result3 = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "--source",
+            "c = 30",
+            "--json",
+        ])
+        .assert_success();
+    let json3 = result3.json_value();
+    assert_eq!(json3["index"], 2);
+    assert_eq!(json3["total_cells"], 3);
+}
+
 // ==================== CELL UPDATE TESTS ====================
 
 #[test]


### PR DESCRIPTION
Fixes #24

When adding cells in remote mode (via Y.js), the total_cells count was showing the count before adding the cell instead of after. This was because the cell is added via Y.js which doesn't update the local notebook variable, so we need to add 1 to the count.

Also renamed "Position" to "Index" in the output for consistency with the CLI's --insert-at option and other parts of the codebase.

Added regression test to verify consecutive cell additions show correct counts.

Fixes #24 