### PR TITLE
Fixes kernel discovery, so kernels in virtual envs are detected

### DIFF
--- a/src/execution/local/discovery.rs
+++ b/src/execution/local/discovery.rs
@@ -78,11 +78,17 @@ fn list_available_kernels() -> Vec<String> {
 /// Get Jupyter kernel directories
 ///
 /// Checks in priority order:
-/// 1. User kernels: ~/.local/share/jupyter/kernels (Linux/Mac)
-/// 2. System kernels: /usr/local/share/jupyter/kernels, /usr/share/jupyter/kernels
-/// 3. Python site-packages kernels
+/// 1. Virtual environment kernels: $VIRTUAL_ENV/share/jupyter/kernels (if VIRTUAL_ENV is set)
+/// 2. User kernels: ~/.local/share/jupyter/kernels (Linux/Mac)
+/// 3. System kernels: /usr/local/share/jupyter/kernels, /usr/share/jupyter/kernels
+/// 4. Python site-packages kernels
 fn get_kernel_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
+
+    // Virtual environment kernels (if VIRTUAL_ENV is set)
+    if let Ok(venv) = std::env::var("VIRTUAL_ENV") {
+        dirs.push(PathBuf::from(venv).join("share").join("jupyter").join("kernels"));
+    }
 
     // User kernels
     if let Some(data_dir) = dirs::data_local_dir() {

--- a/src/execution/local/executor.rs
+++ b/src/execution/local/executor.rs
@@ -3,7 +3,8 @@ use crate::execution::types::{ExecutionConfig, ExecutionError, ExecutionResult};
 use crate::execution::ExecutionBackend;
 use anyhow::{Context, Result};
 use jupyter_protocol::{
-    ConnectionInfo, ExecuteRequest, ExecutionState, JupyterMessage, JupyterMessageContent,
+    ConnectionInfo, ExecuteRequest, ExecutionState, JupyterKernelspec, JupyterMessage,
+    JupyterMessageContent,
 };
 use std::path::PathBuf;
 
@@ -203,19 +204,28 @@ impl LocalExecutor {
 impl ExecutionBackend for LocalExecutor {
     async fn start(&mut self) -> Result<()> {
         // Find kernel
-        let (kernel_name, _kernel_spec_path) = find_kernel(
+        let (kernel_name, kernel_spec_path) = find_kernel(
             self.config.kernel_name.as_deref(),
             None, // Notebook kernel will be passed from command
         )?;
         self.kernel_name = kernel_name.clone();
 
-        // Find kernelspec
-        let kernelspecs = runtimelib::list_kernelspecs().await;
-        let kernel_spec = kernelspecs
-            .iter()
-            .find(|k| k.kernel_name == kernel_name)
-            .context(format!("Kernel '{}' not found", kernel_name))?
-            .clone();
+        // Read kernelspec from the found path
+        let kernel_json_path = kernel_spec_path.join("kernel.json");
+        let kernel_json_content = tokio::fs::read_to_string(&kernel_json_path)
+            .await
+            .context(format!(
+                "Failed to read kernel spec from {}",
+                kernel_json_path.display()
+            ))?;
+        let kernelspec: JupyterKernelspec = serde_json::from_str(&kernel_json_content)
+            .context("Failed to parse kernel.json")?;
+
+        let kernel_spec = runtimelib::KernelspecDir {
+            kernel_name: kernel_name.clone(),
+            path: kernel_spec_path,
+            kernelspec,
+        };
 
         self.kernel_spec = Some(kernel_spec.clone());
 


### PR DESCRIPTION
Tests were failing because the kernel discovery system wasn't respecting the VIRTUAL_ENV environment variable, even though kernels were properly installed in the test virtual environment.

### Root Cause

There were two kernel discovery mechanisms:
1. src/execution/local/discovery.rs - Our own discovery that searches standard Jupyter kernel directories
2. runtimelib::list_kernelspecs() - Third-party library that has its own discovery logic

Neither respected VIRTUAL_ENV, causing tests to fail when no global kernel was installed.

### Fix Applied

**File 1**: src/execution/local/discovery.rs
- Added $VIRTUAL_ENV/share/jupyter/kernels to the search paths (highest priority)
- Only activates when VIRTUAL_ENV is set

**File 2**: src/execution/local/executor.rs
- Changed from using runtimelib::list_kernelspecs() to directly reading the kernel spec from the path found by our discovery
- Now uses the kernel_spec_path returned by find_kernel() instead of ignoring it
- Reads kernel.json directly and constructs the KernelspecDir ourselves

### Impact

- Tests now pass - properly isolated in test venv
- No breaking changes - regular users unaffected (only activates when VIRTUAL_ENV is set)
- Supports venv workflows - users who install kernels with --sys-prefix will now have them properly discovered
- Fallback still works - if no venv kernel exists, still searches global directories