### PR TITLE
Simplify nb create command by replacing --template with --markdown flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ This ensures your AI agent uses the `nb` CLI for all notebook operations instead
 ## Quick Start
 
 ```bash
-# Create and build a notebook
+# Create a notebook (starts with one empty code cell)
 nb create analysis.ipynb
+
+# Add cells
 nb cell add analysis.ipynb --source "import pandas as pd"
 nb cell add analysis.ipynb --source "# Analysis" --type markdown
 nb read analysis.ipynb
@@ -90,7 +92,7 @@ nb read analysis.ipynb --with-outputs
 Local mode lets you create, edit, execute, and query notebooks on disk without any server running. All changes are written directly to the `.ipynb` file.
 
 ```bash
-# Create and edit
+# Create and edit (creates notebook with single code cell)
 nb create notebook.ipynb
 nb cell add notebook.ipynb --source "x = 1 + 1"
 nb cell update notebook.ipynb --cell-index 0 --source "x = 2 + 2"
@@ -176,7 +178,7 @@ nb disconnect
 
 | Command | Purpose |
 |---------|---------|
-| `nb create <path>` | Create a new notebook |
+| `nb create <path>` | Create a new notebook with a single code cell |
 | `nb read <path>` | Read notebook cells and metadata |
 | `nb execute <path>` | Execute cells in notebook |
 | `nb search <path> <pattern>` | Search text and errors in notebook cells |
@@ -231,7 +233,7 @@ nb cell update notebook.ipynb --cell 0 \
 
 **Build notebook programmatically:**
 ```bash
-nb create analysis.ipynb --template basic
+nb create analysis.ipynb
 nb cell add analysis.ipynb --source "import pandas as pd"
 nb cell add analysis.ipynb --source "# Analysis" --type markdown
 nb execute analysis.ipynb

--- a/skills/notebook-cli/SKILL.md
+++ b/skills/notebook-cli/SKILL.md
@@ -32,12 +32,11 @@ nb cell add notebook.ipynb --source "print('hello')"
 ## Create Notebook
 
 ```bash
-# Create empty notebook
+# Create notebook with single empty code cell (default)
 nb create notebook.ipynb
 
-# Create with template
-nb create notebook.ipynb --template basic
-nb create notebook.ipynb --template markdown
+# Create notebook with single empty markdown cell
+nb create notebook.ipynb --markdown
 
 # Create with specific kernel
 nb create notebook.ipynb --kernel python3 --language python

--- a/src/commands/create_notebook.rs
+++ b/src/commands/create_notebook.rs
@@ -1,23 +1,12 @@
 use crate::commands::common::OutputFormat;
 use crate::notebook;
 use anyhow::{bail, Context, Result};
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use nbformat::v4::{Cell, CellId, CellMetadata, KernelSpec, Metadata, Notebook};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 use uuid::Uuid;
-
-#[derive(Clone, ValueEnum)]
-#[value(rename_all = "lowercase")]
-pub enum Template {
-    /// Empty notebook with no cells
-    Empty,
-    /// Basic notebook with one empty code cell
-    Basic,
-    /// Markdown template with heading and code cell
-    Markdown,
-}
 
 #[derive(Parser)]
 pub struct CreateArgs {
@@ -37,14 +26,9 @@ pub struct CreateArgs {
     #[arg(long = "language", default_value = "python", value_name = "LANG")]
     pub language: String,
 
-    /// Template type
-    #[arg(
-        short = 't',
-        long = "template",
-        default_value = "empty",
-        value_name = "TYPE"
-    )]
-    pub template: Template,
+    /// Create notebook with a markdown cell instead of code cell
+    #[arg(long)]
+    pub markdown: bool,
 
     /// Overwrite if file exists
     #[arg(long = "force")]
@@ -58,7 +42,6 @@ pub struct CreateArgs {
 #[derive(Serialize)]
 struct CreateResult {
     file: String,
-    template: String,
     kernel: String,
     cell_count: usize,
 }
@@ -93,15 +76,8 @@ pub fn execute(args: CreateArgs) -> Result<()> {
     notebook::write_notebook_atomic(&path, &notebook).context("Failed to write notebook")?;
 
     // Output result
-    let template_name = match args.template {
-        Template::Empty => "empty",
-        Template::Basic => "basic",
-        Template::Markdown => "markdown",
-    };
-
     let result = CreateResult {
         file: path.clone(),
-        template: template_name.to_string(),
         kernel: args.kernel.clone(),
         cell_count: notebook.cells.len(),
     };
@@ -138,33 +114,24 @@ fn create_notebook(args: &CreateArgs) -> Result<Notebook> {
         ..Default::default()
     };
 
-    // Create cells based on template
+    // Create cells based on markdown flag
     let empty_metadata = create_empty_metadata();
 
-    let cells = match args.template {
-        Template::Empty => vec![],
-        Template::Basic => vec![Cell::Code {
+    let cells = if args.markdown {
+        vec![Cell::Markdown {
             id: CellId::from(Uuid::new_v4()),
-            metadata: empty_metadata.clone(),
+            metadata: empty_metadata,
+            source: vec![],  // Empty markdown cell
+            attachments: None,
+        }]
+    } else {
+        vec![Cell::Code {
+            id: CellId::from(Uuid::new_v4()),
+            metadata: empty_metadata,
             execution_count: None,
             source: vec![],
             outputs: vec![],
-        }],
-        Template::Markdown => vec![
-            Cell::Markdown {
-                id: CellId::from(Uuid::new_v4()),
-                metadata: empty_metadata.clone(),
-                source: vec!["# New Notebook\n".to_string()],
-                attachments: None,
-            },
-            Cell::Code {
-                id: CellId::from(Uuid::new_v4()),
-                metadata: empty_metadata,
-                execution_count: None,
-                source: vec![],
-                outputs: vec![],
-            },
-        ],
+        }]
     };
 
     Ok(Notebook {
@@ -198,7 +165,6 @@ fn output_result(result: &CreateResult, format: &OutputFormat) -> Result<()> {
         }
         OutputFormat::Text => {
             println!("Created notebook: {}", result.file);
-            println!("Template: {}", result.template);
             println!("Kernel: {}", result.kernel);
             println!("Cells: {}", result.cell_count);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Create a new notebook file
+    /// Create a new notebook file (with a single code cell by default)
     Create(commands::create_notebook::CreateArgs),
     /// Read and extract notebook content
     Read(commands::read::ReadArgs),

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -96,7 +96,7 @@ fn join_source(source: &serde_json::Value) -> String {
 // ==================== NOTEBOOK CREATE TESTS ====================
 
 #[test]
-fn test_create_empty_notebook() {
+fn test_create_default_notebook() {
     let env = TestEnv::new();
     let nb_path = env.notebook_path("test.ipynb");
 
@@ -105,35 +105,20 @@ fn test_create_empty_notebook() {
         .assert_success();
 
     let json = result.json_value();
-    assert_eq!(json["template"], "empty");
     assert_eq!(json["kernel"], "python3");
-    assert_eq!(json["cell_count"], 0);
-    assert!(nb_path.exists());
-}
-
-#[test]
-fn test_create_basic_notebook() {
-    let env = TestEnv::new();
-    let nb_path = env.notebook_path("basic.ipynb");
-
-    let result = env
-        .run(&[
-            "create",
-            nb_path.to_str().unwrap(),
-            "--template",
-            "basic",
-            "--json",
-        ])
-        .assert_success();
-
-    let json = result.json_value();
-    assert_eq!(json["template"], "basic");
     assert_eq!(json["cell_count"], 1);
     assert!(nb_path.exists());
+
+    // Verify it's a code cell
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let read_json = read_result.json_value();
+    assert_eq!(read_json["cells"][0]["cell_type"], "code");
 }
 
 #[test]
-fn test_create_markdown_notebook() {
+fn test_create_with_markdown_flag() {
     let env = TestEnv::new();
     let nb_path = env.notebook_path("markdown.ipynb");
 
@@ -141,15 +126,20 @@ fn test_create_markdown_notebook() {
         .run(&[
             "create",
             nb_path.to_str().unwrap(),
-            "--template",
-            "markdown",
+            "--markdown",
             "--json",
         ])
         .assert_success();
 
     let json = result.json_value();
-    assert_eq!(json["template"], "markdown");
-    assert_eq!(json["cell_count"], 2);
+    assert_eq!(json["cell_count"], 1);
+
+    // Verify it's a markdown cell
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let read_json = read_result.json_value();
+    assert_eq!(read_json["cells"][0]["cell_type"], "markdown");
 }
 
 #[test]
@@ -208,7 +198,7 @@ fn test_create_with_force_overwrites() {
         .assert_success();
 
     let json = result.json_value();
-    assert_eq!(json["cell_count"], 0); // Should be empty now
+    assert_eq!(json["cell_count"], 1); // Should have one code cell now
 }
 
 #[test]
@@ -221,8 +211,8 @@ fn test_create_text_format() {
         .assert_success();
 
     assert!(result.stdout.contains("Created notebook:"));
-    assert!(result.stdout.contains("Template:"));
     assert!(result.stdout.contains("Kernel:"));
+    assert!(result.stdout.contains("Cells:"));
 }
 
 // ==================== NOTEBOOK READ TESTS ====================
@@ -1109,7 +1099,7 @@ fn test_workflow_create_add_read() {
         .assert_success();
 
     let json = result.json_value();
-    assert_eq!(json["cells"].as_array().unwrap().len(), 2);
+    assert_eq!(json["cells"].as_array().unwrap().len(), 3);
 }
 
 #[test]


### PR DESCRIPTION
Removes the three-mode template system (empty/basic/markdown) in favor of a simpler two-mode approach:

- Default: Creates notebook with single empty code cell (spec-compliant)
- `--markdown`: Creates notebook with single empty markdown cell

Benefits:

- Simpler, more intuitive API
- Default behavior is now practical and spec-compliant
- Removes unnecessary complexity for common use case

Breaking changes (acceptable for v0.0.x):

- Removed --template flag
- Default now creates 1 code cell instead of 0 cells
- JSON output no longer includes "template" field

Updated tests, documentation, and help text accordingly.