### PR TITLE
Clone file path, not args

### DIFF
--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -195,7 +195,7 @@ async fn execute_with_realtime(
     };
 
     let result = AddCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cell_type: cell_type_str.to_string(),
         cell_id: cell_id.to_string(),
         index: insert_index,
@@ -311,7 +311,7 @@ fn execute_file_based(args: AddCellArgs) -> Result<()> {
     };
 
     let result = AddCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cell_type: cell_type_str.to_string(),
         cell_id: cell_id.to_string(),
         index: insert_index,

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -72,7 +72,7 @@ pub fn execute(args: ClearOutputsArgs) -> Result<()> {
 
     // Output result
     let result = ClearOutputsResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cells_cleared,
         execution_counts_cleared: !args.keep_execution_count,
     };

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -128,7 +128,7 @@ async fn execute_with_realtime(
 
     // Output result
     let result = DeleteCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cells_deleted,
         remaining_cells,
     };
@@ -196,7 +196,7 @@ fn execute_file_based(args: DeleteCellArgs) -> Result<()> {
 
     // Output result
     let result = DeleteCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cells_deleted,
         remaining_cells: notebook.cells.len(),
     };

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -169,7 +169,7 @@ async fn execute_with_realtime(
 
     // Output result
     let result = UpdateCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cell_id,
         index,
         updated: updates,
@@ -315,7 +315,7 @@ fn execute_file_based(args: UpdateCellArgs) -> Result<()> {
 
     // Output result
     let result = UpdateCellResult {
-        file: args.file.clone(),
+        file: file_path.clone(),
         cell_id,
         index,
         updated: updates,


### PR DESCRIPTION
Currently in PR #35 when `cell add`, `cell update`, `cell delete`, `output clear` commands are called without the `.ipynb` extension and with `--json` flag, the `"file"` field in the response shows the path without extension (e.g., `nb cell add test --source "x=1" --json` returns `"file": "test"` instead of `"file": "test.ipynb"`). 

This happens because the result structs use `args.file.clone()` (raw user input) instead of `file_path.clone()` (normalized path). 

To fix, replace `args.file.clone()` with `file_path.clone()` in `add_cell.rs:198`, `add_cell.rs:314`, `update_cell.rs:172`, `update_cell.rs:318`, `delete_cell.rs:131`, `delete_cell.rs:199`, `clear_outputs.rs:75` (verified locally).