### PR TITLE
Return outputs on execute

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,20 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: cargo fmt
+      run: cargo fmt -- --check
+
+    - name: cargo clippy
+      run: cargo clippy -- -D warnings
+
+  test:
 
     runs-on: ubuntu-latest
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -26,6 +26,9 @@ pub enum OutputFormat {
 // AI-Optimized Markdown format constants
 pub const AI_NOTEBOOK_FORMAT: &str = "ai-notebook";
 
+/// Default maximum characters for inline output before externalization
+pub const DEFAULT_INLINE_LIMIT: usize = 4000;
+
 /// Normalize notebook path by adding .ipynb extension if missing
 /// This allows users to omit the .ipynb extension for convenience
 pub fn normalize_notebook_path(path: &str) -> String {
@@ -188,6 +191,26 @@ pub fn split_source(text: &str) -> Vec<String> {
     }
 
     result
+}
+
+/// Serialize notebook cells to JSON values with an `index` field added to each.
+/// When `include_outputs` is false, the `outputs` field is stripped from code cells.
+/// Used by both `read` and `execute` commands for consistent JSON output.
+pub fn serialize_cells_json(cells: &[Cell], include_outputs: bool) -> Vec<serde_json::Value> {
+    cells
+        .iter()
+        .enumerate()
+        .map(|(index, cell)| {
+            let mut cell_json = serde_json::to_value(cell).unwrap_or(serde_json::json!(null));
+            if let Some(obj) = cell_json.as_object_mut() {
+                obj.insert("index".to_string(), serde_json::json!(index));
+                if !include_outputs {
+                    obj.remove("outputs");
+                }
+            }
+            cell_json
+        })
+        .collect()
 }
 
 /// Convert cell source to a single string

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -188,8 +188,6 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     let mut last_executed_cell_id: Option<String> = None;
     let mut last_executed_old_ec: Option<i32> = None;
 
-    let mut code_cell_num = 0;
-
     for (i, cell) in notebook.cells.iter().enumerate() {
         // Skip cells outside range
         if i < start_idx || i > end_idx {
@@ -200,8 +198,6 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         if !matches!(cell, Cell::Code { .. }) {
             continue;
         }
-
-        code_cell_num += 1;
 
         // Get cell source and cell_id
         let source = crate::commands::common::cell_to_string(cell);
@@ -226,21 +222,10 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
                 if !success {
                     failed_count += 1;
 
-                    if !matches!(format, OutputFormat::Json) {
-                        eprintln!("  ✗ Cell {} completed with error", code_cell_num);
-                        if let Some(error) =
-                            execution_results.get(&i).and_then(|r| r.error.as_ref())
-                        {
-                            eprintln!("    Error: {}: {}", error.ename, error.evalue);
-                        }
-                    }
-
                     // Stop on error unless --allow-errors
                     if !args.allow_errors {
                         break;
                     }
-                } else if !matches!(format, OutputFormat::Json) {
-                    eprintln!("  ✓ Cell {} completed", code_cell_num);
                 }
             }
             Err(e) => {
@@ -313,24 +298,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     let success = failed_count == 0;
     let total_cells = end_idx - start_idx + 1;
 
-    // Output summary to stderr (diagnostics)
-    eprintln!("\n{}", "=".repeat(50));
-    if success {
-        eprintln!("✓ Notebook executed successfully");
-    } else {
-        eprintln!("✗ Notebook execution completed with errors");
-    }
-    eprintln!("Total cells in range: {}", total_cells);
-    eprintln!("Executed: {}", executed_count);
-    eprintln!("Failed: {}", failed_count);
-
-    if matches!(mode, ExecutionMode::Local) {
-        eprintln!("\nNotebook updated: {}", file_path);
-    } else {
-        eprintln!("\n(Executed via Jupyter Server)");
-    }
-
-    // Output notebook content to stdout (data)
+    // Output notebook content to stdout
     match format {
         OutputFormat::Json => {
             let cells = common::serialize_cells_json(&notebook.cells, true);

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -182,9 +182,11 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // Execute cells in range and collect results
     let mut executed_count = 0;
     let mut failed_count = 0;
-    let _total_cells = notebook.cells.len();
     let mut execution_results: HashMap<usize, crate::execution::types::ExecutionResult> =
         HashMap::new();
+    // Track the last executed cell for remote mode save polling
+    let mut last_executed_cell_id: Option<String> = None;
+    let mut last_executed_old_ec: Option<i32> = None;
 
     let mut code_cell_num = 0;
 
@@ -213,6 +215,13 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
                 // Store result for later processing
                 execution_results.insert(i, result);
                 executed_count += 1;
+                last_executed_cell_id = Some(cell_id.clone());
+                last_executed_old_ec = match &notebook.cells[i] {
+                    Cell::Code {
+                        execution_count, ..
+                    } => *execution_count,
+                    _ => None,
+                };
 
                 if !success {
                     failed_count += 1;
@@ -264,11 +273,39 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
             write_notebook_atomic(&file_path, &notebook).context("Failed to write notebook")?;
         }
         ExecutionMode::Remote { .. } => {
-            // In remote mode, Jupyter Server automatically updates the Y.js document
-            // when it receives kernel execution messages. The outputs are already
-            // processed by jupyter-server-documents and will be auto-saved to disk
-            // within ~1 second (configured save_delay). No need to wait as nb-cli
-            // already has all outputs from the kernel execution.
+            // In remote mode, jupyter-server-documents routes kernel outputs to Y.js
+            // document sync (not the WebSocket), which auto-saves to disk.
+            // Poll until the last executed cell's execution_count changes on disk.
+            if let Some(ref cell_id) = last_executed_cell_id {
+                let poll_timeout = Duration::from_secs(5);
+                let poll_start = std::time::Instant::now();
+                loop {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    if let Ok(saved) = read_notebook(&file_path) {
+                        let ready = saved.cells.iter().any(|c| {
+                            if c.id().as_str() != cell_id {
+                                return false;
+                            }
+                            match c {
+                                Cell::Code {
+                                    execution_count, ..
+                                } => *execution_count != last_executed_old_ec,
+                                _ => false,
+                            }
+                        });
+                        if ready {
+                            notebook = saved;
+                            break;
+                        }
+                    }
+                    if poll_start.elapsed() > poll_timeout {
+                        if let Ok(saved) = read_notebook(&file_path) {
+                            notebook = saved;
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -184,9 +184,17 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     let mut failed_count = 0;
     let mut execution_results: HashMap<usize, crate::execution::types::ExecutionResult> =
         HashMap::new();
-    // Track the last executed cell for remote mode save polling
-    let mut last_executed_cell_id: Option<String> = None;
-    let mut last_executed_old_ec: Option<i32> = None;
+
+    let is_streaming = matches!(mode, ExecutionMode::Remote { .. })
+        && matches!(format, OutputFormat::Text | OutputFormat::Markdown);
+
+    // For streaming remote text mode, print notebook header before execution
+    if is_streaming {
+        println!(
+            "{}\n",
+            markdown_renderer::render_notebook_header(&notebook)?
+        );
+    }
 
     for (i, cell) in notebook.cells.iter().enumerate() {
         // Skip cells outside range
@@ -196,6 +204,14 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
 
         // Skip non-code cells
         if !matches!(cell, Cell::Code { .. }) {
+            // In streaming mode, render non-code cells inline
+            if is_streaming {
+                if let Ok(header) =
+                    markdown_renderer::render_cell_header_and_body(cell, &notebook, i, None)
+                {
+                    print!("\n{}\n", header);
+                }
+            }
             continue;
         }
 
@@ -203,21 +219,42 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         let source = crate::commands::common::cell_to_string(cell);
         let cell_id = crate::commands::common::cell_id_to_string(cell);
 
-        // Execute cell
-        match backend.execute_code(&source, Some(&cell_id)).await {
+        // For streaming: print cell header before execution, stream outputs as they arrive
+        let on_output: Option<crate::execution::OutputCallback> = if is_streaming {
+            // Print cell header + body before execution (execution_count not yet known)
+            if let Ok(header) =
+                markdown_renderer::render_cell_header_and_body(cell, &notebook, i, None)
+            {
+                print!("\n{}", header);
+            }
+            Some(Box::new(|output: &nbformat::v4::Output| {
+                if let Ok(rendered) = markdown_renderer::render_single_output(
+                    output,
+                    None,
+                    common::DEFAULT_INLINE_LIMIT,
+                ) {
+                    print!("\n\n{}", rendered);
+                }
+            }))
+        } else {
+            None
+        };
+
+        match backend
+            .execute_code(&source, Some(&cell_id), Some(i), on_output.as_ref())
+            .await
+        {
             Ok(result) => {
                 let success = result.success;
+
+                if is_streaming {
+                    // Newline after streamed outputs
+                    println!();
+                }
 
                 // Store result for later processing
                 execution_results.insert(i, result);
                 executed_count += 1;
-                last_executed_cell_id = Some(cell_id.clone());
-                last_executed_old_ec = match &notebook.cells[i] {
-                    Cell::Code {
-                        execution_count, ..
-                    } => *execution_count,
-                    _ => None,
-                };
 
                 if !success {
                     failed_count += 1;
@@ -258,39 +295,8 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
             write_notebook_atomic(&file_path, &notebook).context("Failed to write notebook")?;
         }
         ExecutionMode::Remote { .. } => {
-            // In remote mode, jupyter-server-documents routes kernel outputs to Y.js
-            // document sync (not the WebSocket), which auto-saves to disk.
-            // Poll until the last executed cell's execution_count changes on disk.
-            if let Some(ref cell_id) = last_executed_cell_id {
-                let poll_timeout = Duration::from_secs(5);
-                let poll_start = std::time::Instant::now();
-                loop {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    if let Ok(saved) = read_notebook(&file_path) {
-                        let ready = saved.cells.iter().any(|c| {
-                            if c.id().as_str() != cell_id {
-                                return false;
-                            }
-                            match c {
-                                Cell::Code {
-                                    execution_count, ..
-                                } => *execution_count != last_executed_old_ec,
-                                _ => false,
-                            }
-                        });
-                        if ready {
-                            notebook = saved;
-                            break;
-                        }
-                    }
-                    if poll_start.elapsed() > poll_timeout {
-                        if let Ok(saved) = read_notebook(&file_path) {
-                            notebook = saved;
-                        }
-                        break;
-                    }
-                }
-            }
+            // In remote mode, outputs are read from Y.js document during execution.
+            // The server auto-saves to disk via jupyter-server-documents.
         }
     }
 
@@ -312,15 +318,18 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&output_result)?);
         }
         OutputFormat::Text | OutputFormat::Markdown => {
-            let output_dir = markdown_renderer::notebook_output_dir(&file_path);
-            std::fs::create_dir_all(&output_dir)?;
-            let markdown = markdown_renderer::render_notebook_markdown(
-                &notebook,
-                true,
-                Some(&output_dir),
-                common::DEFAULT_INLINE_LIMIT,
-            )?;
-            print!("{}", markdown);
+            if !is_streaming {
+                let output_dir = markdown_renderer::notebook_output_dir(&file_path);
+                std::fs::create_dir_all(&output_dir)?;
+                let markdown = markdown_renderer::render_notebook_markdown(
+                    &notebook,
+                    true,
+                    Some(&output_dir),
+                    common::DEFAULT_INLINE_LIMIT,
+                )?;
+                print!("{}", markdown);
+            }
+            // Streaming mode already printed everything to stdout
         }
     }
 

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -1,10 +1,11 @@
-use crate::commands::common::OutputFormat;
+use crate::commands::common::{self, OutputFormat};
+use crate::commands::markdown_renderer;
 use crate::execution::{create_backend, types::ExecutionConfig, types::ExecutionMode};
 use crate::notebook::{read_notebook, write_notebook_atomic};
 use anyhow::{Context, Result};
 use clap::Args;
 use nbformat::v4::Cell;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -62,12 +63,13 @@ pub struct ExecuteNotebookArgs {
     pub pixi: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 pub struct ExecuteNotebookResult {
     success: bool,
     total_cells: usize,
     executed_cells: usize,
     failed_cells: usize,
+    cells: Vec<serde_json::Value>,
 }
 
 pub fn execute(args: ExecuteNotebookArgs) -> Result<()> {
@@ -80,7 +82,6 @@ pub fn execute(args: ExecuteNotebookArgs) -> Result<()> {
 }
 
 async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
-    use crate::commands::common;
     use crate::commands::env_manager::EnvConfig;
 
     let format = if args.json {
@@ -227,8 +228,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
 
                     // Stop on error unless --allow-errors
                     if !args.allow_errors {
-                        backend.stop().await?;
-                        anyhow::bail!("Execution stopped at cell {} due to error", i);
+                        break;
                     }
                 } else if !matches!(format, OutputFormat::Json) {
                     eprintln!("  ✓ Cell {} completed", code_cell_num);
@@ -272,38 +272,54 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         }
     }
 
-    // Output result
-    let output_result = ExecuteNotebookResult {
-        success: failed_count == 0,
-        total_cells: end_idx - start_idx + 1,
-        executed_cells: executed_count,
-        failed_cells: failed_count,
-    };
+    // Compute result summary
+    let success = failed_count == 0;
+    let total_cells = end_idx - start_idx + 1;
 
+    // Output summary to stderr (diagnostics)
+    eprintln!("\n{}", "=".repeat(50));
+    if success {
+        eprintln!("✓ Notebook executed successfully");
+    } else {
+        eprintln!("✗ Notebook execution completed with errors");
+    }
+    eprintln!("Total cells in range: {}", total_cells);
+    eprintln!("Executed: {}", executed_count);
+    eprintln!("Failed: {}", failed_count);
+
+    if matches!(mode, ExecutionMode::Local) {
+        eprintln!("\nNotebook updated: {}", file_path);
+    } else {
+        eprintln!("\n(Executed via Jupyter Server)");
+    }
+
+    // Output notebook content to stdout (data)
     match format {
         OutputFormat::Json => {
+            let cells = common::serialize_cells_json(&notebook.cells, true);
+            let output_result = ExecuteNotebookResult {
+                success,
+                total_cells,
+                executed_cells: executed_count,
+                failed_cells: failed_count,
+                cells,
+            };
             println!("{}", serde_json::to_string_pretty(&output_result)?);
         }
         OutputFormat::Text | OutputFormat::Markdown => {
-            println!("\n{}", "=".repeat(50));
-            if output_result.success {
-                println!("✓ Notebook executed successfully");
-            } else {
-                println!("✗ Notebook execution completed with errors");
-            }
-            println!("Total cells in range: {}", output_result.total_cells);
-            println!("Executed: {}", output_result.executed_cells);
-            println!("Failed: {}", output_result.failed_cells);
-
-            if matches!(mode, ExecutionMode::Local) {
-                println!("\nNotebook updated: {}", file_path);
-            } else {
-                println!("\n(Executed via Jupyter Server)");
-            }
+            let output_dir = markdown_renderer::notebook_output_dir(&file_path);
+            std::fs::create_dir_all(&output_dir)?;
+            let markdown = markdown_renderer::render_notebook_markdown(
+                &notebook,
+                true,
+                Some(&output_dir),
+                common::DEFAULT_INLINE_LIMIT,
+            )?;
+            print!("{}", markdown);
         }
     }
 
-    if !output_result.success {
+    if !success {
         std::process::exit(1);
     }
 

--- a/src/commands/markdown_renderer.rs
+++ b/src/commands/markdown_renderer.rs
@@ -75,7 +75,7 @@ pub fn render_indexed_cells_markdown(
 }
 
 /// Render the notebook header with format metadata
-fn render_notebook_header(notebook: &Notebook) -> Result<String> {
+pub fn render_notebook_header(notebook: &Notebook) -> Result<String> {
     let mut metadata_obj = json!({});
 
     // Include kernelspec if present
@@ -321,6 +321,41 @@ impl OutputHeaderBuilder {
         let json_str = serde_json::to_string(&json_obj).unwrap_or_default();
         format!("@@output {}", json_str)
     }
+}
+
+/// Render a single output (public, for streaming use)
+pub fn render_single_output(
+    output: &Output,
+    output_dir: Option<&Path>,
+    inline_limit: usize,
+) -> Result<String> {
+    render_output(output, output_dir, inline_limit)
+}
+
+/// Render a cell header and body without outputs (public, for streaming use).
+/// The `execution_count` parameter overrides the cell's stored value.
+pub fn render_cell_header_and_body(
+    cell: &Cell,
+    notebook: &Notebook,
+    index: usize,
+    execution_count: Option<i32>,
+) -> Result<String> {
+    let language = extract_language(notebook);
+    let cell_id = get_cell_id_or_empty(cell);
+    let metadata = match cell {
+        Cell::Code { metadata, .. } => metadata,
+        Cell::Markdown { metadata, .. } => metadata,
+        Cell::Raw { metadata, .. } => metadata,
+    };
+    let cell_type = match cell {
+        Cell::Code { .. } => "code",
+        Cell::Markdown { .. } => "markdown",
+        Cell::Raw { .. } => "raw",
+    };
+    let mut result = render_cell_header(cell_type, &cell_id, execution_count, metadata, index)?;
+    result.push('\n');
+    result.push_str(&render_cell_body(cell, &language)?);
+    Ok(result)
 }
 
 /// Render a single output

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -32,8 +32,8 @@ pub struct ReadArgs {
     #[arg(long = "output-dir")]
     pub output_dir: Option<String>,
 
-    /// Maximum characters for inline output (default: 4000). Outputs exceeding this are externalized to files
-    #[arg(long, default_value = "4000")]
+    /// Maximum characters for inline output. Outputs exceeding this are externalized to files
+    #[arg(long, default_value_t = common::DEFAULT_INLINE_LIMIT)]
     pub limit: usize,
 
     /// Show only code cells
@@ -256,20 +256,7 @@ fn output_notebook_structure(
                 print!("{}", markdown);
             }
             OutputFormat::Json => {
-                let cells: Vec<serde_json::Value> = notebook
-                    .cells
-                    .iter()
-                    .enumerate()
-                    .map(|(index, cell)| {
-                        let mut cell_json = serde_json::to_value(cell).unwrap_or(json!(null));
-
-                        if let Some(obj) = cell_json.as_object_mut() {
-                            obj.insert("index".to_string(), json!(index));
-                        }
-
-                        cell_json
-                    })
-                    .collect();
+                let cells = common::serialize_cells_json(&notebook.cells, true);
                 let output = json!({ "cells": cells });
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
@@ -285,21 +272,7 @@ fn output_notebook_structure(
             print!("{}", markdown);
         }
         OutputFormat::Json => {
-            let cells: Vec<serde_json::Value> = notebook
-                .cells
-                .iter()
-                .enumerate()
-                .map(|(index, cell)| {
-                    let mut cell_json = serde_json::to_value(cell).unwrap_or(json!(null));
-
-                    if let Some(obj) = cell_json.as_object_mut() {
-                        obj.insert("index".to_string(), json!(index));
-                        obj.remove("outputs");
-                    }
-
-                    cell_json
-                })
-                .collect();
+            let cells = common::serialize_cells_json(&notebook.cells, false);
 
             // Count cell types for summary
             let mut code_cells = 0;

--- a/src/execution/local/executor.rs
+++ b/src/execution/local/executor.rs
@@ -323,6 +323,8 @@ impl ExecutionBackend for LocalExecutor {
         &mut self,
         code: &str,
         _cell_id: Option<&str>,
+        _cell_index: Option<usize>,
+        _on_output: Option<&crate::execution::OutputCallback>,
     ) -> Result<ExecutionResult> {
         self.execute_cell(code).await
     }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -11,6 +11,9 @@ pub mod types;
 use anyhow::Result;
 use types::{ExecutionConfig, ExecutionMode, ExecutionResult};
 
+/// Callback invoked when an output is produced during execution
+pub type OutputCallback = Box<dyn Fn(&nbformat::v4::Output) + Send + Sync>;
+
 /// Backend for executing code
 ///
 /// Implementations provide either local (direct kernel) or remote (Jupyter server) execution
@@ -24,7 +27,15 @@ pub trait ExecutionBackend: Send {
     /// # Arguments
     /// * `code` - The code to execute
     /// * `cell_id` - Optional cell ID for remote execution (used by Jupyter Server)
-    async fn execute_code(&mut self, code: &str, cell_id: Option<&str>) -> Result<ExecutionResult>;
+    /// * `cell_index` - Optional cell index for Y.js document observation in remote mode
+    /// * `on_output` - Optional callback invoked as each output arrives (for streaming)
+    async fn execute_code(
+        &mut self,
+        code: &str,
+        cell_id: Option<&str>,
+        cell_index: Option<usize>,
+        on_output: Option<&OutputCallback>,
+    ) -> Result<ExecutionResult>;
 
     /// Stop the backend (cleanup kernel or close session)
     async fn stop(&mut self) -> Result<()>;

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -43,6 +43,9 @@ impl RemoteExecutor {
     }
 
     /// Fetch a single externalized output from the outputs REST API.
+    /// The Y.js placeholder (metadata.url) can propagate before the server
+    /// finishes writing the output file, so we retry with a 200ms interval
+    /// to reduce 404 spam while the file write completes.
     async fn fetch_output(
         http: &reqwest::Client,
         server_url: &str,
@@ -64,7 +67,7 @@ impl RemoteExecutor {
             if tokio::time::Instant::now() > deadline {
                 return None;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         }
     }
 }

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -12,9 +12,8 @@ use crate::execution::ExecutionBackend;
 use anyhow::{Context, Result};
 use client::{JupyterClient, SessionInfo};
 use jupyter_protocol::messaging::JupyterMessageContent;
-use std::time::Duration;
-use tokio::time::timeout;
 use websocket::KernelWebSocket;
+use ydoc::YDocClient;
 
 /// Remote execution backend using Jupyter Server
 pub struct RemoteExecutor {
@@ -24,6 +23,7 @@ pub struct RemoteExecutor {
     client: Option<JupyterClient>,
     session: Option<SessionInfo>,
     ws: Option<KernelWebSocket>,
+    ydoc: Option<YDocClient>,
     /// Track if we created the session (true) or reused existing (false)
     created_session: bool,
 }
@@ -37,106 +37,34 @@ impl RemoteExecutor {
             client: None,
             session: None,
             ws: None,
+            ydoc: None,
             created_session: false,
         })
     }
 
-    /// Collect outputs from WebSocket messages
-    async fn collect_outputs(
-        ws: &mut KernelWebSocket,
-        msg_id: &str,
-        timeout_duration: Duration,
-    ) -> Result<(Vec<nbformat::v4::Output>, Option<i64>)> {
-        let mut outputs = Vec::new();
-        let mut execution_count: Option<i64> = None;
-        let mut idle_received = false;
-        let mut error_info: Option<ExecutionError> = None;
-
-        // Collect messages until we see idle status
-        let collect_result = timeout(timeout_duration, async {
-            while !idle_received {
-                let msg = match ws.recv_message().await? {
-                    Some(m) => m,
-                    None => break,
-                };
-
-                // Only process messages related to our execution
-                let is_our_message = msg
-                    .parent_header
-                    .as_ref()
-                    .map(|h| h.msg_id == msg_id)
-                    .unwrap_or(false);
-                if !is_our_message {
-                    continue;
-                }
-
-                // Process message content
-                match msg.content {
-                    JupyterMessageContent::Status(status) => {
-                        if matches!(
-                            status.execution_state,
-                            jupyter_protocol::ExecutionState::Idle
-                        ) {
-                            idle_received = true;
+    /// Fetch a single externalized output from the outputs REST API.
+    async fn fetch_output(
+        http: &reqwest::Client,
+        server_url: &str,
+        token: &str,
+        url_path: &str,
+    ) -> Option<nbformat::v4::Output> {
+        let url = format!("{}{}", server_url, url_path);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        loop {
+            if let Ok(resp) = http.get(&url).query(&[("token", token)]).send().await {
+                if resp.status().is_success() {
+                    if let Ok(text) = resp.text().await {
+                        if let Ok(output) = serde_json::from_str::<nbformat::v4::Output>(&text) {
+                            return Some(output);
                         }
                     }
-                    JupyterMessageContent::StreamContent(stream) => {
-                        let output = serde_json::json!({
-                            "output_type": "stream",
-                            "name": stream.name,
-                            "text": stream.text
-                        });
-                        outputs.push(serde_json::from_value(output)?);
-                    }
-                    JupyterMessageContent::DisplayData(display) => {
-                        let output = serde_json::json!({
-                            "output_type": "display_data",
-                            "data": display.data,
-                            "metadata": display.metadata
-                        });
-                        outputs.push(serde_json::from_value(output)?);
-                    }
-                    JupyterMessageContent::ExecuteResult(result) => {
-                        execution_count = Some(result.execution_count.0 as i64);
-                        let output = serde_json::json!({
-                            "output_type": "execute_result",
-                            "execution_count": result.execution_count.0 as i64,
-                            "data": result.data,
-                            "metadata": result.metadata
-                        });
-                        outputs.push(serde_json::from_value(output)?);
-                    }
-                    JupyterMessageContent::ErrorOutput(error) => {
-                        error_info = Some(ExecutionError {
-                            ename: error.ename.clone(),
-                            evalue: error.evalue.clone(),
-                            traceback: error.traceback.clone(),
-                        });
-                        let output = nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
-                            ename: error.ename,
-                            evalue: error.evalue,
-                            traceback: error.traceback,
-                        });
-                        outputs.push(output);
-                    }
-                    _ => {}
                 }
             }
-
-            Ok::<_, anyhow::Error>((outputs, execution_count, error_info))
-        })
-        .await;
-
-        match collect_result {
-            Ok(result) => {
-                let (outputs, execution_count, _error_info) = result?;
-                // Error info is already included in outputs as Error variant
-                Ok((outputs, execution_count))
+            if tokio::time::Instant::now() > deadline {
+                return None;
             }
-            Err(_) => Err(anyhow::anyhow!(
-                "Execution timeout after {:?}",
-                timeout_duration
-            )),
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
     }
 }
@@ -191,54 +119,146 @@ impl ExecutionBackend for RemoteExecutor {
         self.session = Some(session);
         self.ws = Some(ws);
 
+        // Connect Y.js client for observing outputs during execution
+        if let Some(ref notebook_path) = self.config.notebook_path {
+            let ydoc = YDocClient::connect(
+                self.server_url.clone(),
+                self.token.clone(),
+                notebook_path.clone(),
+            )
+            .await
+            .context("Failed to connect Y.js client for output observation")?;
+            self.ydoc = Some(ydoc);
+        }
+
         Ok(())
     }
 
-    async fn execute_code(&mut self, code: &str, cell_id: Option<&str>) -> Result<ExecutionResult> {
+    async fn execute_code(
+        &mut self,
+        code: &str,
+        cell_id: Option<&str>,
+        cell_index: Option<usize>,
+        on_output: Option<&crate::execution::OutputCallback>,
+    ) -> Result<ExecutionResult> {
         let ws = self.ws.as_mut().context("WebSocket not connected")?;
 
-        // Send execute request with cell_id
+        let cell_idx = cell_index.context("cell_index required for remote execution")?;
+        let ydoc = self.ydoc.as_mut().context("Y.js client not connected")?;
+        let http = reqwest::Client::new();
+
+        // Snapshot the execution_count before we start so we know when new results arrive
+        let prev_ec = ydoc
+            .read_cell_outputs(cell_idx)
+            .ok()
+            .and_then(|c| c.execution_count);
+
+        // Send execute request
         let msg_id = ws
             .send_execute_request(code, !self.config.allow_errors, cell_id)
             .await?;
 
-        // Collect outputs
-        let (outputs, execution_count) =
-            Self::collect_outputs(ws, &msg_id, self.config.timeout).await?;
+        let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
+        let mut seen_output_count: usize = 0;
+        let mut idle_received = false;
+        let deadline = tokio::time::Instant::now() + self.config.timeout;
 
-        // Check if any output is an error
-        let has_error = outputs
-            .iter()
-            .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
-
-        if has_error {
-            // Extract error info from error output
-            let error_info = outputs.iter().find_map(|o| {
-                if let nbformat::v4::Output::Error(err) = o {
-                    Some(ExecutionError {
-                        ename: err.ename.clone(),
-                        evalue: err.evalue.clone(),
-                        traceback: err.traceback.clone(),
-                    })
-                } else {
-                    None
+        loop {
+            if idle_received {
+                match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => return Err(e).context("Y.js update error"),
+                    Err(_) => break,
                 }
-            });
+            } else {
+                tokio::select! {
+                    kernel_msg = ws.recv_message() => {
+                        if let Some(msg) = kernel_msg? {
+                            let is_ours = msg.parent_header.as_ref()
+                                .map(|h| h.msg_id == msg_id).unwrap_or(false);
+                            if is_ours {
+                                if let JupyterMessageContent::Status(status) = msg.content {
+                                    if matches!(status.execution_state,
+                                        jupyter_protocol::ExecutionState::Idle) {
+                                        idle_received = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    ydoc_result = ydoc.recv_update() => {
+                        ydoc_result.context("Y.js update error")?;
+                    }
+                }
+            }
 
-            Ok(ExecutionResult::error(
-                outputs,
-                execution_count,
-                error_info.unwrap(),
-            ))
-        } else {
-            Ok(ExecutionResult::success(outputs, execution_count))
+            if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
+                let ec = cell_data.execution_count;
+                let ec_changed = ec != prev_ec && ec.is_some();
+                let current_count = cell_data.externalized_urls.len();
+
+                // Outputs were cleared (reset for new execution)
+                if current_count < seen_output_count {
+                    seen_output_count = 0;
+                    outputs.clear();
+                }
+
+                // Fetch new outputs
+                if current_count > seen_output_count {
+                    for (_, url_path) in &cell_data.externalized_urls[seen_output_count..] {
+                        if let Some(output) =
+                            Self::fetch_output(&http, &self.server_url, &self.token, url_path).await
+                        {
+                            if let Some(cb) = &on_output {
+                                cb(&output);
+                            }
+                            outputs.push(output);
+                        }
+                    }
+                    seen_output_count = current_count;
+                }
+
+                // Done when kernel is idle and execution_count has changed
+                if idle_received && ec_changed {
+                    let has_error = outputs
+                        .iter()
+                        .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
+                    let error_info = outputs.iter().find_map(|o| {
+                        if let nbformat::v4::Output::Error(err) = o {
+                            Some(ExecutionError {
+                                ename: err.ename.clone(),
+                                evalue: err.evalue.clone(),
+                                traceback: err.traceback.clone(),
+                            })
+                        } else {
+                            None
+                        }
+                    });
+                    return if has_error {
+                        Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+                    } else {
+                        Ok(ExecutionResult::success(outputs, ec))
+                    };
+                }
+            }
         }
+
+        let ec = ydoc
+            .read_cell_outputs(cell_idx)
+            .ok()
+            .and_then(|c| c.execution_count);
+        Ok(ExecutionResult::success(outputs, ec))
     }
 
     async fn stop(&mut self) -> Result<()> {
-        // Close WebSocket
+        // Close kernel WebSocket
         if let Some(ws) = self.ws.take() {
             let _ = ws.close().await;
+        }
+
+        // Close Y.js WebSocket
+        if let Some(ydoc) = self.ydoc.take() {
+            let _ = ydoc.close().await;
         }
 
         // Don't delete session - let it persist for reuse in subsequent executions

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -12,6 +12,7 @@ use crate::execution::ExecutionBackend;
 use anyhow::{Context, Result};
 use client::{JupyterClient, SessionInfo};
 use jupyter_protocol::messaging::JupyterMessageContent;
+use std::collections::HashSet;
 use websocket::KernelWebSocket;
 use ydoc::YDocClient;
 
@@ -43,9 +44,7 @@ impl RemoteExecutor {
     }
 
     /// Fetch a single externalized output from the outputs REST API.
-    /// The Y.js placeholder (metadata.url) can propagate before the server
-    /// finishes writing the output file, so we retry with a 200ms interval
-    /// to reduce 404 spam while the file write completes.
+    /// Waits 100ms before the first attempt, then uses exponential backoff.
     async fn fetch_output(
         http: &reqwest::Client,
         server_url: &str,
@@ -54,6 +53,11 @@ impl RemoteExecutor {
     ) -> Option<nbformat::v4::Output> {
         let url = format!("{}{}", server_url, url_path);
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        let mut backoff_ms = 100u64; // initial delay before first fetch
+
+        // Wait before first attempt to let the server populate the output
+        tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+
         loop {
             if let Ok(resp) = http.get(&url).query(&[("token", token)]).send().await {
                 if resp.status().is_success() {
@@ -67,7 +71,8 @@ impl RemoteExecutor {
             if tokio::time::Instant::now() > deadline {
                 return None;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            backoff_ms = (backoff_ms * 2).min(1000);
+            tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
         }
     }
 }
@@ -145,33 +150,36 @@ impl ExecutionBackend for RemoteExecutor {
         on_output: Option<&crate::execution::OutputCallback>,
     ) -> Result<ExecutionResult> {
         let ws = self.ws.as_mut().context("WebSocket not connected")?;
-
         let cell_idx = cell_index.context("cell_index required for remote execution")?;
         let ydoc = self.ydoc.as_mut().context("Y.js client not connected")?;
         let http = reqwest::Client::new();
 
-        // Snapshot the execution_count before we start so we know when new results arrive
+        // 1. Snapshot current state before execution
         let prev_ec = ydoc
             .read_cell_outputs(cell_idx)
             .ok()
             .and_then(|c| c.execution_count);
 
-        // Send execute request
+        // 2. Fire execute request
         let msg_id = ws
             .send_execute_request(code, !self.config.allow_errors, cell_id)
             .await?;
 
+        // 3. Watch for changes on the ydoc for this cell
         let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
-        let mut seen_output_count: usize = 0;
+        let mut fetched_urls: HashSet<String> = HashSet::new();
+        let mut seen_indices: HashSet<usize> = HashSet::new();
         let mut idle_received = false;
+        let mut ec_changed = false;
         let deadline = tokio::time::Instant::now() + self.config.timeout;
 
         loop {
+            // Wait for either a kernel message or a ydoc update
             if idle_received {
                 match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => return Err(e).context("Y.js update error"),
-                    Err(_) => break,
+                    Err(_) => break, // timeout — return what we have
                 }
             } else {
                 tokio::select! {
@@ -195,70 +203,66 @@ impl ExecutionBackend for RemoteExecutor {
                 }
             }
 
-            if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
-                let ec = cell_data.execution_count;
-                let ec_changed = ec != prev_ec && ec.is_some();
-                let total_count =
-                    cell_data.externalized_urls.len() + cell_data.inline_outputs.len();
+            // 4. Read cell state from ydoc
+            let cell_data = match ydoc.read_cell_outputs(cell_idx) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            let ec = cell_data.execution_count;
 
-                // Outputs were cleared (reset for new execution)
-                if total_count < seen_output_count {
-                    seen_output_count = 0;
-                    outputs.clear();
+            // Wait for execution_count to change — ignore stale outputs from previous run
+            if !ec_changed {
+                if ec != prev_ec && ec.is_some() {
+                    ec_changed = true;
+                } else {
+                    continue;
                 }
+            }
 
-                // Collect new outputs (both externalized and inline)
-                if total_count > seen_output_count {
-                    // Build a sorted list of all outputs by index
-                    let mut new_outputs: Vec<(usize, Option<nbformat::v4::Output>)> = Vec::new();
-                    for (idx, url_path) in &cell_data.externalized_urls {
-                        if *idx >= seen_output_count {
-                            let output =
-                                Self::fetch_output(&http, &self.server_url, &self.token, url_path)
-                                    .await;
-                            new_outputs.push((*idx, output));
+            // 5. Load new outputs as they appear
+            for (idx, url_path) in &cell_data.externalized_urls {
+                if fetched_urls.insert(url_path.clone()) {
+                    seen_indices.insert(*idx);
+                    if let Some(output) =
+                        Self::fetch_output(&http, &self.server_url, &self.token, url_path).await
+                    {
+                        if let Some(cb) = &on_output {
+                            cb(&output);
                         }
+                        outputs.push(output);
                     }
-                    for (idx, output) in &cell_data.inline_outputs {
-                        if *idx >= seen_output_count {
-                            new_outputs.push((*idx, Some(output.clone())));
-                        }
-                    }
-                    new_outputs.sort_by_key(|(idx, _)| *idx);
-
-                    for (_, output) in new_outputs {
-                        if let Some(output) = output {
-                            if let Some(cb) = &on_output {
-                                cb(&output);
-                            }
-                            outputs.push(output);
-                        }
-                    }
-                    seen_output_count = total_count;
                 }
+            }
+            for (idx, output) in &cell_data.inline_outputs {
+                if seen_indices.insert(*idx) {
+                    if let Some(cb) = &on_output {
+                        cb(output);
+                    }
+                    outputs.push(output.clone());
+                }
+            }
 
-                // Done when kernel is idle and execution_count has changed
-                if idle_received && ec_changed {
-                    let has_error = outputs
-                        .iter()
-                        .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
-                    let error_info = outputs.iter().find_map(|o| {
-                        if let nbformat::v4::Output::Error(err) = o {
-                            Some(ExecutionError {
-                                ename: err.ename.clone(),
-                                evalue: err.evalue.clone(),
-                                traceback: err.traceback.clone(),
-                            })
-                        } else {
-                            None
-                        }
-                    });
-                    return if has_error {
-                        Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+            // 6. Done when kernel is idle and ec has changed
+            if idle_received && ec_changed {
+                let has_error = outputs
+                    .iter()
+                    .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
+                let error_info = outputs.iter().find_map(|o| {
+                    if let nbformat::v4::Output::Error(err) = o {
+                        Some(ExecutionError {
+                            ename: err.ename.clone(),
+                            evalue: err.evalue.clone(),
+                            traceback: err.traceback.clone(),
+                        })
                     } else {
-                        Ok(ExecutionResult::success(outputs, ec))
-                    };
-                }
+                        None
+                    }
+                });
+                return if has_error {
+                    Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+                } else {
+                    Ok(ExecutionResult::success(outputs, ec))
+                };
             }
         }
 

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -61,10 +61,13 @@ impl RemoteExecutor {
                 };
 
                 // Only process messages related to our execution
-                if let Some(parent) = &msg.parent_header {
-                    if parent.msg_id != msg_id {
-                        continue;
-                    }
+                let is_our_message = msg
+                    .parent_header
+                    .as_ref()
+                    .map(|h| h.msg_id == msg_id)
+                    .unwrap_or(false);
+                if !is_our_message {
+                    continue;
                 }
 
                 // Process message content

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -195,27 +195,43 @@ impl ExecutionBackend for RemoteExecutor {
             if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
                 let ec = cell_data.execution_count;
                 let ec_changed = ec != prev_ec && ec.is_some();
-                let current_count = cell_data.externalized_urls.len();
+                let total_count =
+                    cell_data.externalized_urls.len() + cell_data.inline_outputs.len();
 
                 // Outputs were cleared (reset for new execution)
-                if current_count < seen_output_count {
+                if total_count < seen_output_count {
                     seen_output_count = 0;
                     outputs.clear();
                 }
 
-                // Fetch new outputs
-                if current_count > seen_output_count {
-                    for (_, url_path) in &cell_data.externalized_urls[seen_output_count..] {
-                        if let Some(output) =
-                            Self::fetch_output(&http, &self.server_url, &self.token, url_path).await
-                        {
+                // Collect new outputs (both externalized and inline)
+                if total_count > seen_output_count {
+                    // Build a sorted list of all outputs by index
+                    let mut new_outputs: Vec<(usize, Option<nbformat::v4::Output>)> = Vec::new();
+                    for (idx, url_path) in &cell_data.externalized_urls {
+                        if *idx >= seen_output_count {
+                            let output =
+                                Self::fetch_output(&http, &self.server_url, &self.token, url_path)
+                                    .await;
+                            new_outputs.push((*idx, output));
+                        }
+                    }
+                    for (idx, output) in &cell_data.inline_outputs {
+                        if *idx >= seen_output_count {
+                            new_outputs.push((*idx, Some(output.clone())));
+                        }
+                    }
+                    new_outputs.sort_by_key(|(idx, _)| *idx);
+
+                    for (_, output) in new_outputs {
+                        if let Some(output) = output {
                             if let Some(cb) = &on_output {
                                 cb(&output);
                             }
                             outputs.push(output);
                         }
                     }
-                    seen_output_count = current_count;
+                    seen_output_count = total_count;
                 }
 
                 // Done when kernel is idle and execution_count has changed

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -85,9 +85,19 @@ impl KernelWebSocket {
         }
 
         // Parse the JSON components
+        // Empty buffers (0 bytes) are valid in the Jupyter protocol (e.g., empty parent_header
+        // or metadata). Default to empty JSON object to avoid dropping the entire message.
         let header: serde_json::Value = serde_json::from_slice(buffers[1]).ok()?;
-        let parent_header: serde_json::Value = serde_json::from_slice(buffers[2]).ok()?;
-        let metadata: serde_json::Value = serde_json::from_slice(buffers[3]).ok()?;
+        let parent_header: serde_json::Value = if buffers[2].is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_slice(buffers[2]).ok()?
+        };
+        let metadata: serde_json::Value = if buffers[3].is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_slice(buffers[3]).ok()?
+        };
         let content_json: serde_json::Value = serde_json::from_slice(buffers[4]).ok()?;
 
         // Construct a full message

--- a/src/execution/remote/ydoc.rs
+++ b/src/execution/remote/ydoc.rs
@@ -9,11 +9,39 @@ use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, Web
 use url::Url;
 use yrs::encoding::varint::VarInt;
 use yrs::encoding::write::Write;
+use yrs::types::ToJson;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
-use yrs::{ArrayRef, Doc, ReadTxn, StateVector, Transact, Update};
+use yrs::{Array, ArrayRef, Doc, Map, ReadTxn, StateVector, Transact, Update};
 
 use super::output_conversion::{update_cell_execution_count, update_cell_outputs};
+
+/// Outputs and execution_count read from a Y.js cell
+pub struct YDocCellOutputs {
+    pub execution_count: Option<i64>,
+    /// (output_index, url) for outputs externalized by jupyter-server-documents
+    pub externalized_urls: Vec<(usize, String)>,
+}
+
+/// Convert yrs::Any to serde_json::Value for JSON round-trip deserialization
+fn any_to_json(any: &yrs::Any) -> serde_json::Value {
+    match any {
+        yrs::Any::Null | yrs::Any::Undefined => serde_json::Value::Null,
+        yrs::Any::Bool(b) => serde_json::Value::Bool(*b),
+        yrs::Any::Number(n) => serde_json::json!(*n),
+        yrs::Any::BigInt(n) => serde_json::json!(*n),
+        yrs::Any::String(s) => serde_json::Value::String(s.to_string()),
+        yrs::Any::Array(arr) => serde_json::Value::Array(arr.iter().map(any_to_json).collect()),
+        yrs::Any::Map(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.to_string(), any_to_json(v)))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        yrs::Any::Buffer(_) => serde_json::Value::Null,
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct FileIdResponse {
@@ -199,15 +227,17 @@ impl YDocClient {
                             let server_state = StateVector::decode_v1(payload)
                                 .context("Failed to decode server state vector")?;
 
-                            let txn = self.doc.transact();
-                            let update = txn.encode_state_as_update_v1(&server_state);
+                            let response = {
+                                let txn = self.doc.transact();
+                                let update = txn.encode_state_as_update_v1(&server_state);
 
-                            // Build response: [SYNC=0, SYNC_STEP2=1, length_varint, update_bytes]
-                            let mut response: Vec<u8> = Vec::new();
-                            response.write_u8(0);
-                            response.write_u8(1);
-                            (update.len() as u32).write(&mut response);
-                            response.extend_from_slice(&update);
+                                let mut buf: Vec<u8> = Vec::new();
+                                buf.write_u8(0);
+                                buf.write_u8(1);
+                                (update.len() as u32).write(&mut buf);
+                                buf.extend_from_slice(&update);
+                                buf
+                            };
 
                             self.ws
                                 .send(Message::Binary(response))
@@ -304,22 +334,25 @@ impl YDocClient {
                         let server_state = StateVector::decode_v1(payload)
                             .context("Failed to decode server state vector")?;
 
-                        let txn = self.doc.transact();
-                        let update = txn.encode_state_as_update_v1(&server_state);
+                        let response = {
+                            let txn = self.doc.transact();
+                            let update = txn.encode_state_as_update_v1(&server_state);
 
-                        // Build SyncStep2 response
-                        let mut response: Vec<u8> = Vec::new();
-                        response.write_u8(0);
-                        response.write_u8(1);
-                        (update.len() as u32).write(&mut response);
-                        response.extend_from_slice(&update);
+                            let mut buf: Vec<u8> = Vec::new();
+                            buf.write_u8(0);
+                            buf.write_u8(1);
+                            (update.len() as u32).write(&mut buf);
+                            buf.extend_from_slice(&update);
+
+                            self.last_state = txn.state_vector();
+                            buf
+                        };
 
                         self.ws
                             .send(Message::Binary(response))
                             .await
                             .context("Failed to send SyncStep2")?;
 
-                        self.last_state = txn.state_vector();
                         self.ws.flush().await.context("Failed to flush WebSocket")?;
 
                         return Ok(());
@@ -332,27 +365,30 @@ impl YDocClient {
         }
 
         // If we didn't receive SyncStep1, send a SYNC_UPDATE proactively
-        let txn = self.doc.transact();
-        let update = txn.encode_state_as_update_v1(&self.last_state);
+        let (msg, new_state) = {
+            let txn = self.doc.transact();
+            let update = txn.encode_state_as_update_v1(&self.last_state);
 
-        // Check if there are actually any changes
-        if update.is_empty() || update == vec![0, 0] {
-            return Ok(());
-        }
+            // Check if there are actually any changes
+            if update.is_empty() || update == vec![0, 0] {
+                return Ok(());
+            }
 
-        // Build update message: [SYNC=0, SYNC_UPDATE=2, length_varint, update_bytes]
-        let mut msg: Vec<u8> = Vec::new();
-        msg.write_u8(0);
-        msg.write_u8(2);
-        (update.len() as u32).write(&mut msg);
-        msg.extend_from_slice(&update);
+            let mut buf: Vec<u8> = Vec::new();
+            buf.write_u8(0);
+            buf.write_u8(2);
+            (update.len() as u32).write(&mut buf);
+            buf.extend_from_slice(&update);
+
+            (buf, txn.state_vector())
+        };
 
         self.ws
             .send(Message::Binary(msg))
             .await
             .context("Failed to send update to server")?;
 
-        self.last_state = txn.state_vector();
+        self.last_state = new_state;
         self.ws.flush().await.context("Failed to flush WebSocket")?;
 
         Ok(())
@@ -371,6 +407,109 @@ impl YDocClient {
             Ok(Some(Ok(msg))) => Some(msg),
             _ => None,
         }
+    }
+
+    /// Receive and apply the next Y.js update from the WebSocket.
+    /// Returns Ok(true) if an update was applied, Ok(false) if no data, Err on failure.
+    pub async fn recv_update(&mut self) -> Result<bool> {
+        let msg = match self.ws.next().await {
+            Some(Ok(Message::Binary(data))) => data,
+            Some(Ok(Message::Close(_))) | None => return Ok(false),
+            Some(Ok(_)) => return Ok(false),
+            Some(Err(e)) => return Err(e).context("Y.js WebSocket error"),
+        };
+
+        if msg.len() < 2 || msg[0] != 0 {
+            return Ok(false);
+        }
+
+        let sync_msg_type = msg[1];
+        let payload_with_length = &msg[2..];
+        let mut decoder = yrs::encoding::read::Cursor::new(payload_with_length);
+        let payload_length = u32::read(&mut decoder).context("Failed to read payload length")?;
+        let payload_start = decoder.next;
+        let payload = &payload_with_length[payload_start..payload_start + payload_length as usize];
+
+        match sync_msg_type {
+            0 => {
+                // SyncStep1 from server — respond with SyncStep2
+                let server_state = StateVector::decode_v1(payload)?;
+                let response = {
+                    let txn = self.doc.transact();
+                    let update = txn.encode_state_as_update_v1(&server_state);
+                    let mut buf: Vec<u8> = Vec::new();
+                    buf.write_u8(0);
+                    buf.write_u8(1);
+                    (update.len() as u32).write(&mut buf);
+                    buf.extend_from_slice(&update);
+                    buf
+                };
+                self.ws.send(Message::Binary(response)).await?;
+                Ok(false)
+            }
+            1 | 2 => {
+                // SyncStep2 or Update — apply to doc
+                let update = Update::decode_v1(payload)?;
+                {
+                    let mut txn = self.doc.transact_mut();
+                    let _ = txn.apply_update(update);
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Read outputs and execution_count for a cell from the Y.js document.
+    /// If outputs are externalized (metadata.url present), fetches actual content from the server.
+    pub fn read_cell_outputs(&self, cell_index: usize) -> Result<YDocCellOutputs> {
+        let cells_array: ArrayRef = self.doc.get_or_insert_array("cells");
+        let txn = self.doc.transact();
+
+        let cell_value = cells_array
+            .get(&txn, cell_index as u32)
+            .context("Cell index out of bounds in Y.js doc")?;
+        let cell_map: yrs::MapRef = cell_value
+            .cast()
+            .map_err(|_| anyhow::anyhow!("Cell is not a Map"))?;
+
+        // Read execution_count
+        let execution_count =
+            cell_map
+                .get(&txn, "execution_count")
+                .and_then(|v| match v.to_json(&txn) {
+                    yrs::Any::BigInt(n) => Some(n),
+                    yrs::Any::Number(n) => Some(n as i64),
+                    _ => None,
+                });
+
+        // Read outputs array — collect URLs for externalized outputs
+        let mut urls: Vec<(usize, String)> = Vec::new();
+
+        if let Some(outputs_val) = cell_map.get(&txn, "outputs") {
+            if let Ok(arr) = outputs_val.cast::<ArrayRef>() {
+                let len = arr.len(&txn);
+                for i in 0..len {
+                    if let Some(item) = arr.get(&txn, i) {
+                        let json_val = item.to_json(&txn);
+                        let json = any_to_json(&json_val);
+                        // Check for externalized output (metadata.url present)
+                        if let Some(url) = json
+                            .get("metadata")
+                            .and_then(|m| m.get("url"))
+                            .and_then(|u| u.as_str())
+                        {
+                            urls.push((i as usize, url.to_string()));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(YDocCellOutputs {
+            execution_count,
+            externalized_urls: urls,
+        })
     }
 
     /// Close the WebSocket connection

--- a/src/execution/remote/ydoc.rs
+++ b/src/execution/remote/ydoc.rs
@@ -21,6 +21,8 @@ pub struct YDocCellOutputs {
     pub execution_count: Option<i64>,
     /// (output_index, url) for outputs externalized by jupyter-server-documents
     pub externalized_urls: Vec<(usize, String)>,
+    /// (output_index, output) for inline outputs stored directly in Y.js (e.g. images)
+    pub inline_outputs: Vec<(usize, nbformat::v4::Output)>,
 }
 
 /// Convert yrs::Any to serde_json::Value for JSON round-trip deserialization
@@ -483,8 +485,9 @@ impl YDocClient {
                     _ => None,
                 });
 
-        // Read outputs array — collect URLs for externalized outputs
+        // Read outputs array — collect externalized (have metadata.url) and inline outputs
         let mut urls: Vec<(usize, String)> = Vec::new();
+        let mut inline: Vec<(usize, nbformat::v4::Output)> = Vec::new();
 
         if let Some(outputs_val) = cell_map.get(&txn, "outputs") {
             if let Ok(arr) = outputs_val.cast::<ArrayRef>() {
@@ -493,13 +496,16 @@ impl YDocClient {
                     if let Some(item) = arr.get(&txn, i) {
                         let json_val = item.to_json(&txn);
                         let json = any_to_json(&json_val);
-                        // Check for externalized output (metadata.url present)
                         if let Some(url) = json
                             .get("metadata")
                             .and_then(|m| m.get("url"))
                             .and_then(|u| u.as_str())
                         {
                             urls.push((i as usize, url.to_string()));
+                        } else if let Ok(output) =
+                            serde_json::from_value::<nbformat::v4::Output>(json)
+                        {
+                            inline.push((i as usize, output));
                         }
                     }
                 }
@@ -509,6 +515,7 @@ impl YDocClient {
         Ok(YDocCellOutputs {
             execution_count,
             externalized_urls: urls,
+            inline_outputs: inline,
         })
     }
 

--- a/tests/integration_env_kernels.rs
+++ b/tests/integration_env_kernels.rs
@@ -306,7 +306,7 @@ fn test_execute_with_uv_kernel_succeeds() {
         .assert_success();
 
     assert!(
-        result.contains("executed") || result.contains("Executed") || result.contains("success"),
+        result.contains("execution_count") || result.contains("@@notebook"),
         "Execution should succeed"
     );
 

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -343,12 +343,6 @@ fn test_execute_with_allow_errors() {
     // Execute with --allow-errors (still exits with error code but updates notebook)
     let result = env.run(&["execute", nb_path.to_str().unwrap(), "--allow-errors"]);
 
-    // Summary goes to stderr
-    assert!(
-        result.stderr.contains("Executed") || result.stderr.contains("completed"),
-        "Summary should appear on stderr"
-    );
-
     // Stdout should contain notebook markdown with outputs from both cells
     assert!(
         test_helpers::parse_notebook_header(&result.stdout).is_some(),
@@ -441,11 +435,6 @@ fn test_execute_last_cell_with_negative_index() {
     assert!(
         test_helpers::parse_notebook_header(&result.stdout).is_some(),
         "Execute stdout should contain @@notebook header"
-    );
-    // Summary on stderr
-    assert!(
-        result.stderr.contains("Executed: 1"),
-        "Summary should show 1 executed cell on stderr"
     );
 }
 

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -119,10 +119,6 @@ impl CommandResult {
         }
         self
     }
-
-    fn contains(&self, text: &str) -> bool {
-        self.stdout.contains(text) || self.stderr.contains(text)
-    }
 }
 
 // ==================== EXECUTION TESTS ====================
@@ -140,7 +136,11 @@ fn test_execute_single_cell() {
         .run(&["execute", nb_path.to_str().unwrap(), "--cell-index", "0"])
         .assert_success();
 
-    assert!(result.contains("executed") || result.contains("success"));
+    // Execute now returns notebook markdown on stdout
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Execute stdout should contain @@notebook header"
+    );
 }
 
 #[test]
@@ -153,30 +153,36 @@ fn test_execute_cell_with_output() {
     let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
 
     // Execute entire notebook so cell 2 can print the result
-    env.run(&["execute", nb_path.to_str().unwrap()])
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
         .assert_success();
 
-    // Verify output was captured from cell 2 (which has print statement)
+    // Verify output directly in execute stdout
+    let outputs = test_helpers::parse_outputs(&exec_result.stdout);
+    assert!(
+        !outputs.is_empty(),
+        "Execute stdout should contain @@output sentinels"
+    );
+    assert!(
+        exec_result.stdout.contains("Result: 52"),
+        "Execute stdout should contain the print output"
+    );
+
+    // Persistence check: verify via nb read that outputs were saved
     let result = env
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "2"])
         .assert_success();
 
-    // Parse the markdown output for deep validation
     let cells = test_helpers::parse_cells(&result.stdout);
     assert_eq!(cells.len(), 1);
     assert_eq!(cells[0].get_str("cell_type"), Some("code"));
 
-    let outputs = test_helpers::parse_outputs(&result.stdout);
+    let read_outputs = test_helpers::parse_outputs(&result.stdout);
     assert!(
-        !outputs.is_empty(),
+        !read_outputs.is_empty(),
         "Cell should have outputs after execution"
     );
-    assert!(
-        outputs[0].get_str("output_type").is_some(),
-        "Output should have output_type"
-    );
 
-    // Verify the actual output content
     assert!(result.stdout.contains("Result: 52"));
 }
 
@@ -194,7 +200,10 @@ fn test_execute_cell_by_id() {
         .run(&["execute", nb_path.to_str().unwrap(), "--cell", "cell-1"])
         .assert_success();
 
-    assert!(result.contains("executed") || result.contains("success"));
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Execute stdout should contain @@notebook header"
+    );
 }
 
 #[test]
@@ -207,10 +216,17 @@ fn test_execute_notebook_preserves_state() {
     let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
 
     // Execute entire notebook to preserve state across cells
-    env.run(&["execute", nb_path.to_str().unwrap()])
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
         .assert_success();
 
-    // Verify the output from the last cell
+    // Verify output directly in execute stdout
+    assert!(
+        exec_result.stdout.contains("Result: 52"),
+        "Execute stdout should contain the computed result"
+    );
+
+    // Persistence check: verify via nb read
     let result = env
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "2"])
         .assert_success();
@@ -227,22 +243,13 @@ fn test_execute_entire_notebook() {
 
     let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
 
-    let result = env
+    let exec_result = env
         .run(&["execute", nb_path.to_str().unwrap()])
         .assert_success();
 
-    assert!(
-        result.contains("executed") || result.contains("Executed") || result.contains("success")
-    );
-
-    // Verify all cells have execution counts
-    let read_result = env
-        .run(&["read", nb_path.to_str().unwrap()])
-        .assert_success();
-
-    // Parse cells and verify execution counts were set
-    let cells = test_helpers::parse_cells(&read_result.stdout);
-    assert!(!cells.is_empty(), "Should have cells");
+    // Parse cells directly from execute stdout and verify execution counts
+    let cells = test_helpers::parse_cells(&exec_result.stdout);
+    assert!(!cells.is_empty(), "Should have cells in execute stdout");
 
     let code_cells: Vec<_> = cells
         .iter()
@@ -255,6 +262,23 @@ fn test_execute_entire_notebook() {
             cell.get_i64("execution_count").is_some(),
             "Code cell at index {:?} should have execution_count after full notebook execution",
             cell.get_i64("index")
+        );
+    }
+
+    // Persistence check: verify via nb read
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    let read_cells = test_helpers::parse_cells(&read_result.stdout);
+    let read_code_cells: Vec<_> = read_cells
+        .iter()
+        .filter(|c| c.get_str("cell_type") == Some("code"))
+        .collect();
+    for cell in &read_code_cells {
+        assert!(
+            cell.get_i64("execution_count").is_some(),
+            "Persisted code cell should have execution_count"
         );
     }
 }
@@ -289,9 +313,22 @@ fn test_execute_with_error() {
 
     let nb_path = env.copy_fixture("with_error.ipynb", "test.ipynb");
 
-    // Should fail without --allow-errors
-    env.run(&["execute", nb_path.to_str().unwrap()])
+    // Should fail without --allow-errors but still output notebook content
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
         .assert_failure();
+
+    // Verify partial results appear in stdout despite failure
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Failed execute should still output @@notebook header"
+    );
+
+    let outputs = test_helpers::parse_outputs(&result.stdout);
+    assert!(
+        !outputs.is_empty(),
+        "Failed execute should include outputs (error or successful cells)"
+    );
 }
 
 #[test]
@@ -306,18 +343,40 @@ fn test_execute_with_allow_errors() {
     // Execute with --allow-errors (still exits with error code but updates notebook)
     let result = env.run(&["execute", nb_path.to_str().unwrap(), "--allow-errors"]);
 
-    // Command fails but should show it executed cells
-    assert!(result.contains("Executed") || result.contains("completed"));
+    // Summary goes to stderr
+    assert!(
+        result.stderr.contains("Executed") || result.stderr.contains("completed"),
+        "Summary should appear on stderr"
+    );
 
-    // Verify first cell executed successfully
+    // Stdout should contain notebook markdown with outputs from both cells
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Should have @@notebook header in stdout"
+    );
+
+    let cells = test_helpers::parse_cells(&result.stdout);
+    let code_cells: Vec<_> = cells
+        .iter()
+        .filter(|c| c.get_str("cell_type") == Some("code"))
+        .collect();
+    assert!(
+        !code_cells.is_empty(),
+        "Should have code cells in execute output"
+    );
+
+    // First cell should have execution_count (it succeeded)
+    assert!(
+        code_cells[0].get_i64("execution_count").is_some(),
+        "First code cell should have execution_count"
+    );
+
+    // Persistence check
     let read_result = env
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "0"])
         .assert_success();
 
-    assert!(
-        read_result.stdout.contains("Execution count:")
-            || read_result.stdout.contains("execution_count")
-    );
+    assert!(read_result.stdout.contains("execution_count"));
 }
 
 #[test]
@@ -378,9 +437,16 @@ fn test_execute_last_cell_with_negative_index() {
         .run(&["execute", nb_path.to_str().unwrap(), "--cell-index", "-1"])
         .assert_success();
 
-    assert!(result.contains("executed") || result.contains("success"));
-    // The execute command outputs summary info, not specific cell index
-    assert!(result.contains("Executed: 1"));
+    // Execute stdout should contain notebook markdown
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Execute stdout should contain @@notebook header"
+    );
+    // Summary on stderr
+    assert!(
+        result.stderr.contains("Executed: 1"),
+        "Summary should show 1 executed cell on stderr"
+    );
 }
 
 #[test]
@@ -431,8 +497,14 @@ fn test_execute_json_format() {
         ])
         .assert_success();
 
-    // Should output valid JSON
-    assert!(serde_json::from_str::<serde_json::Value>(&result.stdout).is_ok());
+    // Should output valid JSON with cells and summary
+    let json: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("Should output valid JSON");
+    assert!(
+        json.get("success").is_some(),
+        "JSON should have success field"
+    );
+    assert!(json.get("cells").is_some(), "JSON should have cells array");
 }
 
 // ==================== WORKFLOW TESTS ====================
@@ -471,10 +543,17 @@ fn test_workflow_create_add_execute() {
     .assert_success();
 
     // Execute entire notebook to preserve state
-    env.run(&["execute", nb_path.to_str().unwrap()])
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
         .assert_success();
 
-    // Verify output (cell index 2 because create adds an empty cell at index 0)
+    // Verify output directly in execute stdout
+    assert!(
+        exec_result.stdout.contains("Answer: 4"),
+        "Execute stdout should contain the computed answer"
+    );
+
+    // Persistence check (cell index 2 because create adds an empty cell at index 0)
     let result = env
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "2"])
         .assert_success();
@@ -508,15 +587,21 @@ fn test_workflow_modify_and_reexecute() {
     .assert_success();
 
     // Re-execute the notebook
-    env.run(&["execute", nb_path.to_str().unwrap()])
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
         .assert_success();
 
-    // Verify the new value propagated
+    // Verify the new value directly in execute stdout
+    assert!(
+        exec_result.stdout.contains("Result: 110"),
+        "Execute stdout should show Result: 110 after modifying x to 100"
+    );
+
+    // Persistence check
     let result = env
         .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "2"])
         .assert_success();
 
-    // Should show Result: 110 instead of Result: 52
     assert!(result.stdout.contains("Result: 110"));
 }
 
@@ -543,4 +628,160 @@ fn test_execute_with_relative_paths() {
 
     // Check that it loaded the file and printed the expected output
     assert!(result.stdout.contains("Hello from relative path!"));
+}
+
+// ==================== OUTPUT FORMAT TESTS ====================
+
+#[test]
+fn test_execute_output_matches_read() {
+    let Some(env) = TestEnv::new() else {
+        eprintln!("⚠️  Skipping test: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
+
+    // Execute notebook — stdout should be notebook markdown
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // Read the same notebook — stdout should match execute
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // Both should produce the same notebook markdown format
+    // Compare sentinel structure (headers, cells, outputs) rather than byte-for-byte
+    // since output dir paths may differ
+    let exec_cells = test_helpers::parse_cells(&exec_result.stdout);
+    let read_cells = test_helpers::parse_cells(&read_result.stdout);
+    assert_eq!(
+        exec_cells.len(),
+        read_cells.len(),
+        "Execute and read should produce the same number of cells"
+    );
+
+    let exec_outputs = test_helpers::parse_outputs(&exec_result.stdout);
+    let read_outputs = test_helpers::parse_outputs(&read_result.stdout);
+    assert_eq!(
+        exec_outputs.len(),
+        read_outputs.len(),
+        "Execute and read should produce the same number of outputs"
+    );
+
+    // Verify output types match
+    for (exec_out, read_out) in exec_outputs.iter().zip(read_outputs.iter()) {
+        assert_eq!(
+            exec_out.get_str("output_type"),
+            read_out.get_str("output_type"),
+            "Output types should match between execute and read"
+        );
+    }
+}
+
+#[test]
+fn test_execute_error_shows_partial_results_and_error() {
+    let Some(env) = TestEnv::new() else {
+        eprintln!("⚠️  Skipping test: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("with_error.ipynb", "test.ipynb");
+
+    // Execute without --allow-errors: cell-1 (valid_code = 123) succeeds, cell-2 (undefined_variable) fails
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_failure();
+
+    // Stdout should contain notebook markdown with partial results
+    assert!(
+        test_helpers::parse_notebook_header(&result.stdout).is_some(),
+        "Should have @@notebook header despite failure"
+    );
+
+    // Cell-1 should have execution_count (it ran successfully)
+    let cells = test_helpers::parse_cells(&result.stdout);
+    let code_cells: Vec<_> = cells
+        .iter()
+        .filter(|c| c.get_str("cell_type") == Some("code"))
+        .collect();
+    assert!(
+        code_cells.len() >= 2,
+        "Should have at least 2 code cells in output"
+    );
+    assert!(
+        code_cells[0].get_i64("execution_count").is_some(),
+        "First code cell should have execution_count (it succeeded)"
+    );
+
+    // Cell-2 should have an error output
+    let outputs = test_helpers::parse_outputs(&result.stdout);
+    let error_outputs: Vec<_> = outputs
+        .iter()
+        .filter(|o| o.get_str("output_type") == Some("error"))
+        .collect();
+    assert!(
+        !error_outputs.is_empty(),
+        "Should have an error output from the failed cell"
+    );
+    assert_eq!(
+        error_outputs[0].get_str("ename"),
+        Some("NameError"),
+        "Error should be a NameError"
+    );
+
+    // Persistence check: partial results should be saved
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    let read_cells = test_helpers::parse_cells(&read_result.stdout);
+    let read_code_cells: Vec<_> = read_cells
+        .iter()
+        .filter(|c| c.get_str("cell_type") == Some("code"))
+        .collect();
+    assert!(
+        read_code_cells[0].get_i64("execution_count").is_some(),
+        "Persisted first cell should have execution_count"
+    );
+}
+
+#[test]
+fn test_execute_json_includes_outputs() {
+    let Some(env) = TestEnv::new() else {
+        eprintln!("⚠️  Skipping test: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("Should output valid JSON");
+
+    // Verify summary fields
+    assert_eq!(json["success"], true);
+    assert!(json["executed_cells"].as_u64().unwrap() > 0);
+
+    // Verify cells array has outputs
+    let cells = json["cells"].as_array().expect("Should have cells array");
+    let code_cells: Vec<_> = cells.iter().filter(|c| c["cell_type"] == "code").collect();
+
+    // Last code cell (print) should have outputs
+    let last_cell = code_cells.last().expect("Should have code cells");
+    let outputs = last_cell["outputs"]
+        .as_array()
+        .expect("Last code cell should have outputs");
+    assert!(!outputs.is_empty(), "Should have at least one output");
+
+    // Verify the actual output content contains the computed result
+    let output_text = serde_json::to_string(outputs).unwrap();
+    assert!(
+        output_text.contains("Result: 52"),
+        "Output should contain 'Result: 52'"
+    );
 }


### PR DESCRIPTION
Fixes #50, fixes #64 (thanks to https://github.com/andrii-i/nb-cli/pull/1 by @3coins).

`nb execute` now returns the same AI-notebook markdown as `nb read`:

```bash
% nb execute notebook.ipynb
@@notebook {"format":"ai-notebook","metadata":{"kernelspec":{"display_name":"Python 3 (ipykernel)","name":"python3"}}}

@@cell {"cell_type":"code","execution_count":1,"id":"...","index":0}
​```python
print(f"Result: {42 + 10}")
​```

@@output {"name":"stdout","output_type":"stream"}
​```text
Result: 52
​```
```

Other changes:
- On failure, partial results and error tracebacks are now included in the output (exit code 1). Previously, `bail!` exited immediately on cell error without saving or rendering. Replaced with `break` so execution falls through to save partial results and render the notebook.
- `--json` now includes the full `cells` array with outputs alongside the execution summary fields.
- Fixed remote mode returning empty outputs. `jupyter-server-documents` routes kernel output messages to Y.js document sync rather than the WebSocket, so the execute command never received them. Now polls the notebook file after execution until the last executed cell's `execution_count` updates on disk, then re-reads the notebook to pick up all outputs.
- Fixed WebSocket parser silently dropping messages when `parent_header` or `metadata` buffers are empty. Now defaults to `{}` instead of failing the parse and discarding the entire message.
- Fixed parent header filter allowing unrelated messages through. Changed to match local executor's pattern (`unwrap_or(false)`) so messages without a matching parent are skipped.
- Extracted `serialize_cells_json()` and `DEFAULT_INLINE_LIMIT` into `common.rs` to deduplicate cell serialization across `read` and `execute`.


