### PR TITLE
Add multi-cell support to nb cell add using @@code/@@markdown/@@raw

### DIFF
--- a/skills/notebook-cli/SKILL.md
+++ b/skills/notebook-cli/SKILL.md
@@ -43,7 +43,8 @@ nb cell update notebook.ipynb --cell-index 2 --source "new code"
 # Add cell
 nb cell add notebook.ipynb --source "print('hello')"
 
-# Add multiple cells (use @@code, @@markdown, @@raw sentinels)
+# Add multiple cells (start with a sentinel: @@code, @@markdown, @@raw,
+# or @@cell {"cell_type":"..."})
 nb cell add notebook.ipynb -s '@@code
 import pandas as pd
 @@code
@@ -178,10 +179,15 @@ echo "print('Hello')" | nb cell add notebook.ipynb --source -
 
 ### Adding Multiple Cells
 
-Use `@@code`, `@@markdown`, and `@@raw` sentinels on their own line within the `--source` string to add multiple cells in a single call. Each sentinel starts a new cell of that type; everything between sentinels is the cell's source content.
+Start the `--source` string with a sentinel line to add multiple cells in a single call. Multi-cell mode is activated only when the **first non-empty line** is a sentinel; otherwise the entire source is treated as a single cell. This means `@@code`/`@@markdown`/`@@raw` appearing inside cell content (e.g., in documentation) is treated as literal text — no data loss.
+
+Two sentinel formats are supported:
+
+- **Shorthand**: `@@code`, `@@markdown`, `@@raw`
+- **Full format** (matches `nb read` output): `@@cell {"cell_type": "code"}` — may include a `"metadata"` object that is loaded into the cell
 
 ```bash
-# Add multiple code cells
+# Add multiple code cells (shorthand)
 nb cell add notebook.ipynb -s '@@code
 x = 1
 @@code
@@ -199,6 +205,12 @@ df = pd.read_csv("data.csv")
 ## Results
 @@code
 df.describe()'
+
+# Full @@cell format with metadata
+nb cell add notebook.ipynb -s '@@cell {"cell_type": "code", "metadata": {"tags": ["setup"]}}
+import pandas as pd
+@@cell {"cell_type": "markdown"}
+# Analysis'
 
 # Insert multiple cells at a position
 nb cell add notebook.ipynb -s '@@code
@@ -223,9 +235,9 @@ df = pd.read_csv("data.csv")
 EOF
 ```
 
-When sentinels are present, the `--type` flag is ignored (each sentinel specifies its own type). The `--id` flag cannot be used with multiple cells. Content before the first sentinel is ignored.
+When sentinels are present, the `--type` flag is ignored (each sentinel specifies its own type). The `--id` flag cannot be used with multiple cells. Leading and trailing blank lines are stripped from each cell.
 
-When no sentinels are present, the source is treated as a single cell using `--type` (backward compatible).
+When no sentinels are present (first non-empty line is not a sentinel), the source is treated as a single cell using `--type` (backward compatible).
 
 ## Update Cell
 

--- a/skills/notebook-cli/SKILL.md
+++ b/skills/notebook-cli/SKILL.md
@@ -42,6 +42,12 @@ nb cell update notebook.ipynb --cell-index 2 --source "new code"
 
 # Add cell
 nb cell add notebook.ipynb --source "print('hello')"
+
+# Add multiple cells (use @@code, @@markdown, @@raw sentinels)
+nb cell add notebook.ipynb -s '@@code
+import pandas as pd
+@@code
+df = pd.read_csv("data.csv")'
 ```
 
 ## Running Python in the Correct Environment
@@ -169,6 +175,57 @@ nb cell add notebook.ipynb --source "code" --id "my-custom-id"
 # Read from stdin
 echo "print('Hello')" | nb cell add notebook.ipynb --source -
 ```
+
+### Adding Multiple Cells
+
+Use `@@code`, `@@markdown`, and `@@raw` sentinels on their own line within the `--source` string to add multiple cells in a single call. Each sentinel starts a new cell of that type; everything between sentinels is the cell's source content.
+
+```bash
+# Add multiple code cells
+nb cell add notebook.ipynb -s '@@code
+x = 1
+@@code
+y = 2
+@@code
+print(x + y)'
+
+# Mix cell types
+nb cell add notebook.ipynb -s '@@markdown
+# Analysis
+@@code
+import pandas as pd
+df = pd.read_csv("data.csv")
+@@markdown
+## Results
+@@code
+df.describe()'
+
+# Insert multiple cells at a position
+nb cell add notebook.ipynb -s '@@code
+import numpy as np
+@@code
+data = np.random.rand(100)' --insert-at 0
+
+# Insert multiple cells after a specific cell
+nb cell add notebook.ipynb -s '@@code
+step_1()
+@@code
+step_2()' --after "cell-id-123"
+
+# Via stdin
+cat <<'EOF' | nb cell add notebook.ipynb -s -
+@@markdown
+# Setup
+@@code
+import pandas as pd
+@@code
+df = pd.read_csv("data.csv")
+EOF
+```
+
+When sentinels are present, the `--type` flag is ignored (each sentinel specifies its own type). The `--id` flag cannot be used with multiple cells. Content before the first sentinel is ignored.
+
+When no sentinels are present, the source is treated as a single cell using `--type` (backward compatible).
 
 ## Update Cell
 

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -101,7 +101,7 @@ fn parse_multi_cell_source(text: &str) -> Option<Vec<ParsedCell>> {
     // sentinel. This prevents accidental data loss when cell content happens
     // to contain @@code/@@markdown/@@raw as literal text.
     let first_non_empty = lines.iter().find(|line| !line.trim().is_empty());
-    if first_non_empty.map_or(true, |line| parse_sentinel(line).is_none()) {
+    if first_non_empty.is_none_or(|line| parse_sentinel(line).is_none()) {
         return None;
     }
 
@@ -155,9 +155,18 @@ struct SentinelInfo {
 fn parse_sentinel(line: &str) -> Option<SentinelInfo> {
     let trimmed = line.trim();
     match trimmed {
-        "@@code" => Some(SentinelInfo { cell_type: CellType::Code, metadata: None }),
-        "@@markdown" => Some(SentinelInfo { cell_type: CellType::Markdown, metadata: None }),
-        "@@raw" => Some(SentinelInfo { cell_type: CellType::Raw, metadata: None }),
+        "@@code" => Some(SentinelInfo {
+            cell_type: CellType::Code,
+            metadata: None,
+        }),
+        "@@markdown" => Some(SentinelInfo {
+            cell_type: CellType::Markdown,
+            metadata: None,
+        }),
+        "@@raw" => Some(SentinelInfo {
+            cell_type: CellType::Raw,
+            metadata: None,
+        }),
         _ if trimmed.starts_with("@@cell ") => {
             let json_str = trimmed.strip_prefix("@@cell ")?.trim();
             let json: serde_json::Value = serde_json::from_str(json_str).ok()?;
@@ -170,7 +179,10 @@ fn parse_sentinel(line: &str) -> Option<SentinelInfo> {
             let metadata = json
                 .get("metadata")
                 .and_then(|v| serde_json::from_value::<CellMetadata>(v.clone()).ok());
-            Some(SentinelInfo { cell_type, metadata })
+            Some(SentinelInfo {
+                cell_type,
+                metadata,
+            })
         }
         _ => None,
     }
@@ -626,17 +638,15 @@ mod tests {
         );
 
         // Metadata with editable flag
-        let info = parse_sentinel(
-            r#"@@cell {"cell_type": "markdown", "metadata": {"editable": false}}"#,
-        )
-        .unwrap();
+        let info =
+            parse_sentinel(r#"@@cell {"cell_type": "markdown", "metadata": {"editable": false}}"#)
+                .unwrap();
         assert!(matches!(info.cell_type, CellType::Markdown));
         let meta = info.metadata.unwrap();
         assert_eq!(meta.editable, Some(false));
 
         // Empty metadata object — deserialized but all fields are None
-        let info =
-            parse_sentinel(r#"@@cell {"cell_type": "code", "metadata": {}}"#).unwrap();
+        let info = parse_sentinel(r#"@@cell {"cell_type": "code", "metadata": {}}"#).unwrap();
         assert!(info.metadata.is_some());
 
         // Full nb read-style sentinel with metadata

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -2,7 +2,7 @@ use crate::commands::common::{self, CellType, OutputFormat};
 use crate::notebook;
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use nbformat::v4::{Cell, CellId};
+use nbformat::v4::{Cell, CellId, CellMetadata};
 use serde::Serialize;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -21,8 +21,9 @@ pub struct AddCellArgs {
     )]
     pub cell_type: CellType,
 
-    /// Cell source content (use '-' for stdin). Use @@code, @@markdown, @@raw
-    /// sentinels on their own line to add multiple cells in one call.
+    /// Cell source content (use '-' for stdin). Start with a sentinel line
+    /// (@@code, @@markdown, @@raw, or @@cell {"cell_type":"..."}) to add
+    /// multiple cells in one call.
     #[arg(short = 's', long = "source", value_name = "TEXT", default_value = "")]
     pub source: String,
 
@@ -83,40 +84,48 @@ struct AddedCellInfo {
 struct ParsedCell {
     cell_type: CellType,
     source: Vec<String>,
+    metadata: Option<CellMetadata>,
 }
 
 /// Try to parse the source text as sentinel-delimited multi-cell input.
 ///
-/// Recognizes `@@code`, `@@markdown`, and `@@raw` on their own line as cell
-/// delimiters. Returns `None` if no sentinels are found (caller should treat the
-/// entire text as a single cell).
+/// Recognizes `@@code`, `@@markdown`, `@@raw`, and `@@cell {"cell_type": "..."}` on
+/// their own line as cell delimiters. Multi-cell mode is only activated when the
+/// first non-empty line is a sentinel; this prevents accidental data loss when cell
+/// content happens to mention these tokens. Returns `None` if the first non-empty
+/// line is not a sentinel (caller should treat the entire text as a single cell).
 fn parse_multi_cell_source(text: &str) -> Option<Vec<ParsedCell>> {
     let lines: Vec<&str> = text.lines().collect();
 
-    let has_sentinels = lines.iter().any(|line| sentinel_type(line).is_some());
-    if !has_sentinels {
+    // Multi-cell mode is only activated when the first non-empty line is a
+    // sentinel. This prevents accidental data loss when cell content happens
+    // to contain @@code/@@markdown/@@raw as literal text.
+    let first_non_empty = lines.iter().find(|line| !line.trim().is_empty());
+    if first_non_empty.map_or(true, |line| parse_sentinel(line).is_none()) {
         return None;
     }
 
     let mut cells = Vec::new();
     let mut current_type: Option<CellType> = None;
+    let mut current_metadata: Option<CellMetadata> = None;
     let mut current_lines: Vec<&str> = Vec::new();
 
     for line in &lines {
-        if let Some(cell_type) = sentinel_type(line) {
+        if let Some(info) = parse_sentinel(line) {
             // Finish previous cell if any
             if let Some(ct) = current_type.take() {
                 cells.push(ParsedCell {
                     cell_type: ct,
                     source: common::split_source(&join_cell_lines(&current_lines)),
+                    metadata: current_metadata.take(),
                 });
                 current_lines.clear();
             }
-            current_type = Some(cell_type);
+            current_type = Some(info.cell_type);
+            current_metadata = info.metadata;
         } else if current_type.is_some() {
             current_lines.push(line);
         }
-        // Lines before the first sentinel are ignored
     }
 
     // Finish last cell
@@ -124,44 +133,77 @@ fn parse_multi_cell_source(text: &str) -> Option<Vec<ParsedCell>> {
         cells.push(ParsedCell {
             cell_type: ct,
             source: common::split_source(&join_cell_lines(&current_lines)),
+            metadata: current_metadata,
         });
     }
 
     Some(cells)
 }
 
-/// Match a sentinel line to a cell type.
-fn sentinel_type(line: &str) -> Option<CellType> {
-    match line.trim() {
-        "@@code" => Some(CellType::Code),
-        "@@markdown" => Some(CellType::Markdown),
-        "@@raw" => Some(CellType::Raw),
+/// Parsed sentinel data: cell type and optional metadata from the JSON block.
+struct SentinelInfo {
+    cell_type: CellType,
+    metadata: Option<CellMetadata>,
+}
+
+/// Parse a sentinel line into its cell type and optional metadata.
+///
+/// Accepts both shorthand (`@@code`, `@@markdown`, `@@raw`) and the full
+/// `@@cell {"cell_type": "...", "metadata": {...}}` format produced by `nb read`.
+/// When the `@@cell` JSON format includes a `"metadata"` object, it is deserialized
+/// as `CellMetadata` and carried through to cell creation.
+fn parse_sentinel(line: &str) -> Option<SentinelInfo> {
+    let trimmed = line.trim();
+    match trimmed {
+        "@@code" => Some(SentinelInfo { cell_type: CellType::Code, metadata: None }),
+        "@@markdown" => Some(SentinelInfo { cell_type: CellType::Markdown, metadata: None }),
+        "@@raw" => Some(SentinelInfo { cell_type: CellType::Raw, metadata: None }),
+        _ if trimmed.starts_with("@@cell ") => {
+            let json_str = trimmed.strip_prefix("@@cell ")?.trim();
+            let json: serde_json::Value = serde_json::from_str(json_str).ok()?;
+            let cell_type = match json.get("cell_type")?.as_str()? {
+                "code" => CellType::Code,
+                "markdown" => CellType::Markdown,
+                "raw" => CellType::Raw,
+                _ => return None,
+            };
+            let metadata = json
+                .get("metadata")
+                .and_then(|v| serde_json::from_value::<CellMetadata>(v.clone()).ok());
+            Some(SentinelInfo { cell_type, metadata })
+        }
         _ => None,
     }
 }
 
-/// Join content lines back into a single string, stripping trailing blank lines.
+/// Join content lines back into a single string, stripping leading and trailing
+/// blank lines so that each cell has no empty lines at the top or bottom.
 fn join_cell_lines(lines: &[&str]) -> String {
+    let mut start = 0;
+    while start < lines.len() && lines[start].is_empty() {
+        start += 1;
+    }
     let mut end = lines.len();
-    while end > 0 && lines[end - 1].is_empty() {
+    while end > start && lines[end - 1].is_empty() {
         end -= 1;
     }
-    if end == 0 {
+    if start >= end {
         return String::new();
     }
-    lines[..end].join("\n")
+    lines[start..end].join("\n")
 }
 
 /// Parse source text into one or more cells.
 ///
-/// If the text contains `@@code`/`@@markdown`/`@@raw` sentinels, each sentinel
-/// starts a new cell of that type. Otherwise a single cell of `default_type` is
-/// returned.
+/// If the first non-empty line is a sentinel (`@@code`/`@@markdown`/`@@raw` or
+/// `@@cell {"cell_type": "..."}`), multi-cell mode is activated and each sentinel
+/// starts a new cell. Otherwise a single cell of `default_type` is returned.
 fn parse_source_into_cells(text: &str, default_type: &CellType) -> Vec<ParsedCell> {
     parse_multi_cell_source(text).unwrap_or_else(|| {
         vec![ParsedCell {
             cell_type: default_type.clone(),
             source: common::split_source(text),
+            metadata: None,
         }]
     })
 }
@@ -263,7 +305,7 @@ async fn execute_with_realtime(
         };
 
         let cell_type_str = cell_type_to_str(&parsed.cell_type);
-        let metadata = create_empty_metadata();
+        let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
         let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
 
         added_cells.push(AddedCellInfo {
@@ -367,7 +409,7 @@ fn execute_file_based(args: AddCellArgs) -> Result<()> {
         };
 
         let cell_type_str = cell_type_to_str(&parsed.cell_type);
-        let metadata = create_empty_metadata();
+        let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
         let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
 
         let actual_index = insert_index + i;
@@ -515,19 +557,95 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sentinel_type() {
-        assert!(matches!(sentinel_type("@@code"), Some(CellType::Code)));
+    fn test_parse_sentinel_shorthand() {
+        let info = parse_sentinel("@@code").unwrap();
+        assert!(matches!(info.cell_type, CellType::Code));
+        assert!(info.metadata.is_none());
+
+        let info = parse_sentinel("@@markdown").unwrap();
+        assert!(matches!(info.cell_type, CellType::Markdown));
+        assert!(info.metadata.is_none());
+
+        let info = parse_sentinel("@@raw").unwrap();
+        assert!(matches!(info.cell_type, CellType::Raw));
+        assert!(info.metadata.is_none());
+
+        assert!(parse_sentinel("@@output").is_none());
+        assert!(parse_sentinel("not a sentinel").is_none());
+        assert!(parse_sentinel("").is_none());
+        // Trimmed
         assert!(matches!(
-            sentinel_type("@@markdown"),
+            parse_sentinel("  @@code  ").map(|i| i.cell_type),
+            Some(CellType::Code)
+        ));
+    }
+
+    #[test]
+    fn test_parse_sentinel_cell_json() {
+        // Full @@cell {json} format (matches nb read output)
+        let info = parse_sentinel(r#"@@cell {"cell_type": "code"}"#).unwrap();
+        assert!(matches!(info.cell_type, CellType::Code));
+        assert!(info.metadata.is_none());
+
+        assert!(matches!(
+            parse_sentinel(r#"@@cell {"cell_type": "markdown"}"#).map(|i| i.cell_type),
             Some(CellType::Markdown)
         ));
-        assert!(matches!(sentinel_type("@@raw"), Some(CellType::Raw)));
-        assert!(sentinel_type("@@cell").is_none());
-        assert!(sentinel_type("@@output").is_none());
-        assert!(sentinel_type("not a sentinel").is_none());
-        assert!(sentinel_type("").is_none());
-        // Trimmed
-        assert!(matches!(sentinel_type("  @@code  "), Some(CellType::Code)));
+        assert!(matches!(
+            parse_sentinel(r#"@@cell {"cell_type": "raw"}"#).map(|i| i.cell_type),
+            Some(CellType::Raw)
+        ));
+        // With extra fields (as produced by nb read) — no metadata key
+        let info = parse_sentinel(
+            r#"@@cell {"index":0,"id":"abc","cell_type":"code","execution_count":1}"#,
+        )
+        .unwrap();
+        assert!(matches!(info.cell_type, CellType::Code));
+        assert!(info.metadata.is_none());
+
+        // @@cell without JSON or with invalid JSON
+        assert!(parse_sentinel("@@cell").is_none());
+        assert!(parse_sentinel("@@cell {}").is_none());
+        assert!(parse_sentinel("@@cell not-json").is_none());
+        // Unknown cell_type
+        assert!(parse_sentinel(r#"@@cell {"cell_type": "unknown"}"#).is_none());
+    }
+
+    #[test]
+    fn test_parse_sentinel_cell_json_with_metadata() {
+        // Metadata with tags
+        let info = parse_sentinel(
+            r#"@@cell {"cell_type": "code", "metadata": {"tags": ["test", "important"]}}"#,
+        )
+        .unwrap();
+        assert!(matches!(info.cell_type, CellType::Code));
+        let meta = info.metadata.unwrap();
+        assert_eq!(
+            meta.tags.as_ref().unwrap(),
+            &vec!["test".to_string(), "important".to_string()]
+        );
+
+        // Metadata with editable flag
+        let info = parse_sentinel(
+            r#"@@cell {"cell_type": "markdown", "metadata": {"editable": false}}"#,
+        )
+        .unwrap();
+        assert!(matches!(info.cell_type, CellType::Markdown));
+        let meta = info.metadata.unwrap();
+        assert_eq!(meta.editable, Some(false));
+
+        // Empty metadata object — deserialized but all fields are None
+        let info =
+            parse_sentinel(r#"@@cell {"cell_type": "code", "metadata": {}}"#).unwrap();
+        assert!(info.metadata.is_some());
+
+        // Full nb read-style sentinel with metadata
+        let info = parse_sentinel(
+            r#"@@cell {"index":0,"id":"abc","cell_type":"code","metadata":{"tags":["auto"]}}"#,
+        )
+        .unwrap();
+        let meta = info.metadata.unwrap();
+        assert_eq!(meta.tags.as_ref().unwrap(), &vec!["auto".to_string()]);
     }
 
     #[test]
@@ -577,16 +695,72 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_multi_cell_content_before_first_sentinel_ignored() {
+    fn test_parse_multi_cell_content_before_sentinel_is_single_cell() {
+        // When the first non-empty line is NOT a sentinel, multi-cell mode is
+        // not activated — the entire text is treated as single-cell content.
+        // This prevents data loss when cell content mentions @@code etc.
         let input = "ignored preamble\n@@code\nx = 1";
+        assert!(parse_multi_cell_source(input).is_none());
+    }
+
+    #[test]
+    fn test_parse_multi_cell_leading_blank_lines_before_sentinel() {
+        // Leading blank lines before the first sentinel are fine
+        let input = "\n\n@@code\nx = 1";
         let cells = parse_multi_cell_source(input).unwrap();
         assert_eq!(cells.len(), 1);
         assert_eq!(cells[0].source.join(""), "x = 1");
     }
 
     #[test]
+    fn test_parse_multi_cell_cell_json_format() {
+        // Accept @@cell {json} format (matches nb read output)
+        let input = "@@cell {\"cell_type\": \"code\"}\nx = 1\n@@cell {\"cell_type\": \"markdown\"}\n# Title";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert!(matches!(cells[0].cell_type, CellType::Code));
+        assert_eq!(cells[0].source.join(""), "x = 1");
+        assert!(cells[0].metadata.is_none());
+        assert!(matches!(cells[1].cell_type, CellType::Markdown));
+        assert_eq!(cells[1].source.join(""), "# Title");
+        assert!(cells[1].metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_multi_cell_cell_json_with_metadata() {
+        // Metadata from @@cell JSON is carried through to ParsedCell
+        let input = "@@cell {\"cell_type\": \"code\", \"metadata\": {\"tags\": [\"setup\"]}}\nx = 1\n@@cell {\"cell_type\": \"markdown\"}\n# Title";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        let meta = cells[0].metadata.as_ref().unwrap();
+        assert_eq!(meta.tags.as_ref().unwrap(), &vec!["setup".to_string()]);
+        assert!(cells[1].metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_multi_cell_mixed_shorthand_and_json() {
+        // Mix shorthand and @@cell {json} formats
+        let input = "@@code\nx = 1\n@@cell {\"cell_type\": \"markdown\"}\n# Title";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert!(matches!(cells[0].cell_type, CellType::Code));
+        assert!(cells[0].metadata.is_none());
+        assert!(matches!(cells[1].cell_type, CellType::Markdown));
+        assert!(cells[1].metadata.is_none());
+    }
+
+    #[test]
     fn test_parse_multi_cell_trailing_blank_lines_stripped() {
         let input = "@@code\nx = 1\n\n\n@@markdown\n# Title\n\n";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].source.join(""), "x = 1");
+        assert_eq!(cells[1].source.join(""), "# Title");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_leading_blank_lines_in_cell_stripped() {
+        let input = "@@code\n\n\nx = 1\n@@markdown\n\n# Title";
         let cells = parse_multi_cell_source(input).unwrap();
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0].source.join(""), "x = 1");

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -12,7 +12,7 @@ pub struct AddCellArgs {
     /// Path to notebook file
     pub file: String,
 
-    /// Cell type
+    /// Cell type (used when source has no @@code/@@markdown/@@raw sentinels)
     #[arg(
         short = 't',
         long = "type",
@@ -21,7 +21,8 @@ pub struct AddCellArgs {
     )]
     pub cell_type: CellType,
 
-    /// Cell source content (use '-' for stdin)
+    /// Cell source content (use '-' for stdin). Use @@code, @@markdown, @@raw
+    /// sentinels on their own line to add multiple cells in one call.
     #[arg(short = 's', long = "source", value_name = "TEXT", default_value = "")]
     pub source: String,
 
@@ -63,6 +64,108 @@ struct AddCellResult {
     total_cells: usize,
 }
 
+#[derive(Serialize)]
+struct AddCellsResult {
+    file: String,
+    cells_added: usize,
+    total_cells: usize,
+    cells: Vec<AddedCellInfo>,
+}
+
+#[derive(Serialize)]
+struct AddedCellInfo {
+    cell_type: String,
+    cell_id: String,
+    index: usize,
+}
+
+/// A cell parsed from sentinel-delimited source input.
+struct ParsedCell {
+    cell_type: CellType,
+    source: Vec<String>,
+}
+
+/// Try to parse the source text as sentinel-delimited multi-cell input.
+///
+/// Recognizes `@@code`, `@@markdown`, and `@@raw` on their own line as cell
+/// delimiters. Returns `None` if no sentinels are found (caller should treat the
+/// entire text as a single cell).
+fn parse_multi_cell_source(text: &str) -> Option<Vec<ParsedCell>> {
+    let lines: Vec<&str> = text.lines().collect();
+
+    let has_sentinels = lines.iter().any(|line| sentinel_type(line).is_some());
+    if !has_sentinels {
+        return None;
+    }
+
+    let mut cells = Vec::new();
+    let mut current_type: Option<CellType> = None;
+    let mut current_lines: Vec<&str> = Vec::new();
+
+    for line in &lines {
+        if let Some(cell_type) = sentinel_type(line) {
+            // Finish previous cell if any
+            if let Some(ct) = current_type.take() {
+                cells.push(ParsedCell {
+                    cell_type: ct,
+                    source: common::split_source(&join_cell_lines(&current_lines)),
+                });
+                current_lines.clear();
+            }
+            current_type = Some(cell_type);
+        } else if current_type.is_some() {
+            current_lines.push(line);
+        }
+        // Lines before the first sentinel are ignored
+    }
+
+    // Finish last cell
+    if let Some(ct) = current_type {
+        cells.push(ParsedCell {
+            cell_type: ct,
+            source: common::split_source(&join_cell_lines(&current_lines)),
+        });
+    }
+
+    Some(cells)
+}
+
+/// Match a sentinel line to a cell type.
+fn sentinel_type(line: &str) -> Option<CellType> {
+    match line.trim() {
+        "@@code" => Some(CellType::Code),
+        "@@markdown" => Some(CellType::Markdown),
+        "@@raw" => Some(CellType::Raw),
+        _ => None,
+    }
+}
+
+/// Join content lines back into a single string, stripping trailing blank lines.
+fn join_cell_lines(lines: &[&str]) -> String {
+    let mut end = lines.len();
+    while end > 0 && lines[end - 1].is_empty() {
+        end -= 1;
+    }
+    if end == 0 {
+        return String::new();
+    }
+    lines[..end].join("\n")
+}
+
+/// Parse source text into one or more cells.
+///
+/// If the text contains `@@code`/`@@markdown`/`@@raw` sentinels, each sentinel
+/// starts a new cell of that type. Otherwise a single cell of `default_type` is
+/// returned.
+fn parse_source_into_cells(text: &str, default_type: &CellType) -> Vec<ParsedCell> {
+    parse_multi_cell_source(text).unwrap_or_else(|| {
+        vec![ParsedCell {
+            cell_type: default_type.clone(),
+            source: common::split_source(text),
+        }]
+    })
+}
+
 pub fn execute(args: AddCellArgs) -> Result<()> {
     // Check if we should use real-time Y.js updates by resolving execution mode
     use crate::execution::types::ExecutionMode;
@@ -100,46 +203,17 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook to calculate insertion index and create cell
+    // Read notebook to calculate insertion index and create cells
     let notebook = notebook::read_notebook(&file_path).context("Failed to read notebook")?;
 
-    // Parse source content
-    let source = common::parse_source(&args.source)?;
+    // Parse source content into cells
+    let raw_text = common::parse_source_text(&args.source)?;
+    let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
 
-    // Generate or validate cell ID
-    let cell_id = if let Some(id) = args.id {
-        if notebook.cells.iter().any(|c| c.id().as_str() == id) {
-            bail!("Cell ID '{}' already exists in notebook", id);
-        }
-        CellId::new(&id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
-    } else {
-        CellId::from(Uuid::new_v4())
-    };
-
-    // Create metadata
-    let metadata = create_empty_metadata();
-
-    // Create the new cell
-    let new_cell = match args.cell_type {
-        CellType::Code => Cell::Code {
-            id: cell_id.clone(),
-            metadata,
-            execution_count: None,
-            source,
-            outputs: vec![],
-        },
-        CellType::Markdown => Cell::Markdown {
-            id: cell_id.clone(),
-            metadata,
-            source,
-            attachments: None,
-        },
-        CellType::Raw => Cell::Raw {
-            id: cell_id.clone(),
-            metadata,
-            source,
-        },
-    };
+    // Validate: --id can only be used with a single cell
+    if parsed_cells.len() > 1 && args.id.is_some() {
+        bail!("--id cannot be used when adding multiple cells");
+    }
 
     // Determine insertion index
     let insert_index = if let Some(idx) = args.insert_at {
@@ -174,38 +248,58 @@ async fn execute_with_realtime(
         notebook.cells.len()
     };
 
-    // Add cell via Y.js (don't write to file - let JupyterLab handle persistence)
-    ydoc_notebook_ops::ydoc_add_cell(
+    // Create all cells
+    let mut new_cells: Vec<Cell> = Vec::new();
+    let mut added_cells: Vec<AddedCellInfo> = Vec::new();
+
+    for (i, parsed) in parsed_cells.into_iter().enumerate() {
+        let cell_id = if let Some(ref id) = args.id {
+            if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
+                bail!("Cell ID '{}' already exists in notebook", id);
+            }
+            CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+        } else {
+            CellId::from(Uuid::new_v4())
+        };
+
+        let cell_type_str = cell_type_to_str(&parsed.cell_type);
+        let metadata = create_empty_metadata();
+        let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
+
+        added_cells.push(AddedCellInfo {
+            cell_type: cell_type_str.to_string(),
+            cell_id: cell_id.to_string(),
+            index: insert_index + i,
+        });
+
+        new_cells.push(new_cell);
+    }
+
+    // Add cells via Y.js (don't write to file - let JupyterLab handle persistence)
+    ydoc_notebook_ops::ydoc_add_cells(
         &server_url,
         &token,
         &notebook_server_path,
-        &new_cell,
+        &new_cells,
         insert_index,
     )
     .await
-    .context("Error adding cell")?;
+    .context("Error adding cells")?;
 
     // Output result
-    let cell_type_str = match args.cell_type {
-        CellType::Code => "code",
-        CellType::Markdown => "markdown",
-        CellType::Raw => "raw",
-    };
-
-    let result = AddCellResult {
-        file: file_path.clone(),
-        cell_type: cell_type_str.to_string(),
-        cell_id: cell_id.to_string(),
-        index: insert_index,
-        total_cells: notebook.cells.len() + 1,
-    };
-
     let format = if args.json {
         OutputFormat::Json
     } else {
         OutputFormat::Text
     };
-    output_result(&result, &format)?;
+
+    let num_added = added_cells.len();
+    output_results(
+        &file_path,
+        added_cells,
+        notebook.cells.len() + num_added,
+        &format,
+    )?;
 
     Ok(())
 }
@@ -217,50 +311,18 @@ fn execute_file_based(args: AddCellArgs) -> Result<()> {
     // Read notebook
     let mut notebook = notebook::read_notebook(&file_path).context("Failed to read notebook")?;
 
-    // Parse source content (may read from stdin)
-    let source = common::parse_source(&args.source)?;
+    // Parse source content into cells
+    let raw_text = common::parse_source_text(&args.source)?;
+    let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
 
-    // Generate or validate cell ID
-    let cell_id = if let Some(id) = args.id {
-        // Validate that ID is unique
-        if notebook.cells.iter().any(|c| c.id().as_str() == id) {
-            bail!("Cell ID '{}' already exists in notebook", id);
-        }
-        CellId::new(&id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
-    } else {
-        CellId::from(Uuid::new_v4())
-    };
-
-    // Create empty metadata
-    let metadata = create_empty_metadata();
-
-    // Create the new cell
-    let new_cell = match args.cell_type {
-        CellType::Code => Cell::Code {
-            id: cell_id.clone(),
-            metadata,
-            execution_count: None,
-            source,
-            outputs: vec![],
-        },
-        CellType::Markdown => Cell::Markdown {
-            id: cell_id.clone(),
-            metadata,
-            source,
-            attachments: None,
-        },
-        CellType::Raw => Cell::Raw {
-            id: cell_id.clone(),
-            metadata,
-            source,
-        },
-    };
+    // Validate: --id can only be used with a single cell
+    if parsed_cells.len() > 1 && args.id.is_some() {
+        bail!("--id cannot be used when adding multiple cells");
+    }
 
     // Determine insertion index
     let insert_index = if let Some(idx) = args.insert_at {
-        // Insert at specific index
         if idx < 0 {
-            // Negative index: insert from end
             let abs_idx = idx.unsigned_abs() as usize;
             if abs_idx > notebook.cells.len() {
                 bail!(
@@ -271,7 +333,6 @@ fn execute_file_based(args: AddCellArgs) -> Result<()> {
             }
             notebook.cells.len() - abs_idx
         } else {
-            // Positive index: can be len() for append
             let pos_idx = idx as usize;
             if pos_idx > notebook.cells.len() {
                 bail!(
@@ -283,47 +344,91 @@ fn execute_file_based(args: AddCellArgs) -> Result<()> {
             pos_idx
         }
     } else if let Some(ref after_id) = args.after {
-        // Insert after specific cell
         let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
         index + 1
     } else if let Some(ref before_id) = args.before {
-        // Insert before specific cell
         let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
         index
     } else {
-        // Default: append to end
         notebook.cells.len()
     };
 
-    // Insert the new cell
-    notebook.cells.insert(insert_index, new_cell);
+    // Create and insert cells
+    let mut added_cells: Vec<AddedCellInfo> = Vec::new();
+
+    for (i, parsed) in parsed_cells.into_iter().enumerate() {
+        let cell_id = if let Some(ref id) = args.id {
+            if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
+                bail!("Cell ID '{}' already exists in notebook", id);
+            }
+            CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+        } else {
+            CellId::from(Uuid::new_v4())
+        };
+
+        let cell_type_str = cell_type_to_str(&parsed.cell_type);
+        let metadata = create_empty_metadata();
+        let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
+
+        let actual_index = insert_index + i;
+        notebook.cells.insert(actual_index, new_cell);
+
+        added_cells.push(AddedCellInfo {
+            cell_type: cell_type_str.to_string(),
+            cell_id: cell_id.to_string(),
+            index: actual_index,
+        });
+    }
 
     // Write notebook atomically
     notebook::write_notebook_atomic(&file_path, &notebook).context("Failed to write notebook")?;
 
     // Output result
-    let cell_type_str = match args.cell_type {
-        CellType::Code => "code",
-        CellType::Markdown => "markdown",
-        CellType::Raw => "raw",
-    };
-
-    let result = AddCellResult {
-        file: file_path.clone(),
-        cell_type: cell_type_str.to_string(),
-        cell_id: cell_id.to_string(),
-        index: insert_index,
-        total_cells: notebook.cells.len(),
-    };
-
     let format = if args.json {
         OutputFormat::Json
     } else {
         OutputFormat::Text
     };
-    output_result(&result, &format)?;
+
+    output_results(&file_path, added_cells, notebook.cells.len(), &format)?;
 
     Ok(())
+}
+
+fn cell_type_to_str(ct: &CellType) -> &'static str {
+    match ct {
+        CellType::Code => "code",
+        CellType::Markdown => "markdown",
+        CellType::Raw => "raw",
+    }
+}
+
+fn create_cell(
+    cell_type: CellType,
+    id: CellId,
+    metadata: nbformat::v4::CellMetadata,
+    source: Vec<String>,
+) -> Cell {
+    match cell_type {
+        CellType::Code => Cell::Code {
+            id,
+            metadata,
+            execution_count: None,
+            source,
+            outputs: vec![],
+        },
+        CellType::Markdown => Cell::Markdown {
+            id,
+            metadata,
+            source,
+            attachments: None,
+        },
+        CellType::Raw => Cell::Raw {
+            id,
+            metadata,
+            source,
+        },
+    }
 }
 
 fn create_empty_metadata() -> nbformat::v4::CellMetadata {
@@ -342,6 +447,33 @@ fn create_empty_metadata() -> nbformat::v4::CellMetadata {
     }
 }
 
+fn output_results(
+    file: &str,
+    added_cells: Vec<AddedCellInfo>,
+    total_cells: usize,
+    format: &OutputFormat,
+) -> Result<()> {
+    if added_cells.len() == 1 {
+        let info = &added_cells[0];
+        let result = AddCellResult {
+            file: file.to_string(),
+            cell_type: info.cell_type.clone(),
+            cell_id: info.cell_id.clone(),
+            index: info.index,
+            total_cells,
+        };
+        output_result(&result, format)
+    } else {
+        let result = AddCellsResult {
+            file: file.to_string(),
+            cells_added: added_cells.len(),
+            total_cells,
+            cells: added_cells,
+        };
+        output_multi_result(&result, format)
+    }
+}
+
 fn output_result(result: &AddCellResult, format: &OutputFormat) -> Result<()> {
     match format {
         OutputFormat::Json => {
@@ -357,4 +489,107 @@ fn output_result(result: &AddCellResult, format: &OutputFormat) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn output_multi_result(result: &AddCellsResult, format: &OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        OutputFormat::Text | OutputFormat::Markdown => {
+            println!("Added {} cells to: {}", result.cells_added, result.file);
+            for cell in &result.cells {
+                println!(
+                    "  Cell ID: {} (type: {}, index: {})",
+                    cell.cell_id, cell.cell_type, cell.index
+                );
+            }
+            println!("Total cells: {}", result.total_cells);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sentinel_type() {
+        assert!(matches!(sentinel_type("@@code"), Some(CellType::Code)));
+        assert!(matches!(
+            sentinel_type("@@markdown"),
+            Some(CellType::Markdown)
+        ));
+        assert!(matches!(sentinel_type("@@raw"), Some(CellType::Raw)));
+        assert!(sentinel_type("@@cell").is_none());
+        assert!(sentinel_type("@@output").is_none());
+        assert!(sentinel_type("not a sentinel").is_none());
+        assert!(sentinel_type("").is_none());
+        // Trimmed
+        assert!(matches!(sentinel_type("  @@code  "), Some(CellType::Code)));
+    }
+
+    #[test]
+    fn test_parse_multi_cell_no_sentinels() {
+        assert!(parse_multi_cell_source("x = 1\ny = 2").is_none());
+        assert!(parse_multi_cell_source("").is_none());
+        assert!(parse_multi_cell_source("just plain text").is_none());
+    }
+
+    #[test]
+    fn test_parse_multi_cell_single_sentinel() {
+        let cells = parse_multi_cell_source("@@code\nx = 1").unwrap();
+        assert_eq!(cells.len(), 1);
+        assert!(matches!(cells[0].cell_type, CellType::Code));
+        assert_eq!(cells[0].source.join(""), "x = 1");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_multiple_sentinels() {
+        let input = "@@code\nx = 1\n@@markdown\n# Title\n@@raw\nraw stuff";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 3);
+        assert!(matches!(cells[0].cell_type, CellType::Code));
+        assert_eq!(cells[0].source.join(""), "x = 1");
+        assert!(matches!(cells[1].cell_type, CellType::Markdown));
+        assert_eq!(cells[1].source.join(""), "# Title");
+        assert!(matches!(cells[2].cell_type, CellType::Raw));
+        assert_eq!(cells[2].source.join(""), "raw stuff");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_multiline_source() {
+        let input = "@@code\nx = 1\ny = 2\nz = 3\n@@markdown\n# Title\nSome text";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].source.join(""), "x = 1\ny = 2\nz = 3");
+        assert_eq!(cells[1].source.join(""), "# Title\nSome text");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_empty_cell() {
+        let input = "@@code\n@@markdown\n# Title";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert!(cells[0].source.is_empty());
+        assert_eq!(cells[1].source.join(""), "# Title");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_content_before_first_sentinel_ignored() {
+        let input = "ignored preamble\n@@code\nx = 1";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].source.join(""), "x = 1");
+    }
+
+    #[test]
+    fn test_parse_multi_cell_trailing_blank_lines_stripped() {
+        let input = "@@code\nx = 1\n\n\n@@markdown\n# Title\n\n";
+        let cells = parse_multi_cell_source(input).unwrap();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].source.join(""), "x = 1");
+        assert_eq!(cells[1].source.join(""), "# Title");
+    }
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -99,19 +99,22 @@ pub fn find_cell_by_id_mut<'a>(
 /// Parse source text from a string or stdin (when input is "-")
 /// Returns a Vec<String> in Jupyter's line format
 pub fn parse_source(input: &str) -> Result<Vec<String>> {
-    let text = if input == "-" {
-        // Read from stdin
+    let text = parse_source_text(input)?;
+    Ok(split_source(&text))
+}
+
+/// Parse source text from a string or stdin (when input is "-")
+/// Returns the raw text string (without converting to Jupyter line format)
+pub fn parse_source_text(input: &str) -> Result<String> {
+    if input == "-" {
         let mut buffer = String::new();
         io::stdin()
             .read_to_string(&mut buffer)
             .context("Failed to read from stdin")?;
-        buffer
+        Ok(buffer)
     } else {
-        // Unescape common escape sequences
-        unescape_string(input)
-    };
-
-    Ok(split_source(&text))
+        Ok(unescape_string(input))
+    }
 }
 
 /// Unescape common escape sequences in a string

--- a/src/execution/remote/ydoc_notebook_ops.rs
+++ b/src/execution/remote/ydoc_notebook_ops.rs
@@ -6,35 +6,6 @@ use yrs::{Any, Array, ArrayPrelim, Map, MapPrelim, MapRef, Text, TextPrelim, Tra
 
 use super::ydoc::YDocClient;
 
-/// Add a new cell to the notebook via Y.js
-pub async fn ydoc_add_cell(
-    server_url: &str,
-    token: &str,
-    notebook_path: &str,
-    cell: &Cell,
-    index: usize,
-) -> Result<()> {
-    // Connect to Y.js document
-    let mut ydoc_client = YDocClient::connect(
-        server_url.to_string(),
-        token.to_string(),
-        notebook_path.to_string(),
-    )
-    .await?;
-
-    // Add the cell to the Y.js document
-    add_cell_to_ydoc(ydoc_client.get_doc(), cell, index)
-        .context("Failed to add cell to Y.js document")?;
-
-    // Sync changes
-    ydoc_client.sync().await.context("Failed to sync changes")?;
-
-    // Close connection
-    ydoc_client.close().await?;
-
-    Ok(())
-}
-
 /// Add a cell to the Y.js document
 fn add_cell_to_ydoc(doc: &yrs::Doc, cell: &Cell, index: usize) -> Result<()> {
     let cells_array = doc.get_or_insert_array("cells");
@@ -135,6 +106,37 @@ fn add_cell_to_ydoc(doc: &yrs::Doc, cell: &Cell, index: usize) -> Result<()> {
 /// Convert source Vec<String> to a single string
 fn source_to_string(source: &[String]) -> String {
     source.join("")
+}
+
+/// Add cells to the notebook via Y.js in a single connection
+pub async fn ydoc_add_cells(
+    server_url: &str,
+    token: &str,
+    notebook_path: &str,
+    cells: &[Cell],
+    start_index: usize,
+) -> Result<()> {
+    // Connect to Y.js document
+    let mut ydoc_client = YDocClient::connect(
+        server_url.to_string(),
+        token.to_string(),
+        notebook_path.to_string(),
+    )
+    .await?;
+
+    // Add all cells to the Y.js document consecutively
+    for (i, cell) in cells.iter().enumerate() {
+        add_cell_to_ydoc(ydoc_client.get_doc(), cell, start_index + i)
+            .context("Failed to add cell to Y.js document")?;
+    }
+
+    // Sync changes
+    ydoc_client.sync().await.context("Failed to sync changes")?;
+
+    // Close connection
+    ydoc_client.close().await?;
+
+    Ok(())
 }
 
 /// Delete cells from the notebook via Y.js

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -1179,6 +1179,129 @@ fn test_add_single_sentinel_still_uses_type() {
     assert!(json["cell_id"].is_string());
 }
 
+#[test]
+fn test_add_cells_with_cell_json_format() {
+    // Accept @@cell {"cell_type": "..."} format (matches nb read output)
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@cell {\"cell_type\": \"code\"}\nx = 1\n@@cell {\"cell_type\": \"markdown\"}\n# Title",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 2);
+
+    let cells = json["cells"].as_array().unwrap();
+    assert_eq!(cells[0]["cell_type"], "code");
+    assert_eq!(cells[1]["cell_type"], "markdown");
+
+    // Verify sources by reading the notebook
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(join_source(&nb_cells[0]["source"]), "x = 1");
+    assert_eq!(join_source(&nb_cells[1]["source"]), "# Title");
+}
+
+#[test]
+fn test_add_cell_content_with_sentinel_literal_not_lost() {
+    // Content that mentions @@code should NOT trigger multi-cell mode
+    // when the first non-empty line is not a sentinel
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "Use @@code to start a code cell",
+            "-t",
+            "markdown",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    // Single-cell format, not multi-cell
+    assert_eq!(json["cell_type"], "markdown");
+    assert!(json["cell_id"].is_string());
+
+    // Verify the full content is preserved (no data loss)
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(
+        join_source(&nb_cells[0]["source"]),
+        "Use @@code to start a code cell"
+    );
+}
+
+#[test]
+fn test_add_cell_with_metadata_from_sentinel_json() {
+    // Metadata in the @@cell JSON block should be written to the notebook
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            r#"@@cell {"cell_type": "code", "metadata": {"tags": ["setup", "hidden"]}}
+x = 1
+@@cell {"cell_type": "markdown", "metadata": {"editable": false}}
+# Read-only title
+@@code
+plain cell"#,
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 3);
+
+    // Read back the raw notebook JSON to verify metadata persisted
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+
+    // First cell: tags from sentinel metadata
+    let meta0 = &nb_cells[0]["metadata"];
+    let tags: Vec<&str> = meta0["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(tags, vec!["setup", "hidden"]);
+
+    // Second cell: editable flag from sentinel metadata
+    let meta1 = &nb_cells[1]["metadata"];
+    assert_eq!(meta1["editable"], false);
+
+    // Third cell: shorthand sentinel — empty metadata
+    let meta2 = &nb_cells[2]["metadata"];
+    assert!(meta2.is_object());
+    assert!(meta2.as_object().unwrap().is_empty() || !meta2.as_object().unwrap().contains_key("tags"));
+}
+
 // ==================== CELL UPDATE TESTS ====================
 
 #[test]

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -1299,7 +1299,9 @@ plain cell"#,
     // Third cell: shorthand sentinel — empty metadata
     let meta2 = &nb_cells[2]["metadata"];
     assert!(meta2.is_object());
-    assert!(meta2.as_object().unwrap().is_empty() || !meta2.as_object().unwrap().contains_key("tags"));
+    assert!(
+        meta2.as_object().unwrap().is_empty() || !meta2.as_object().unwrap().contains_key("tags")
+    );
 }
 
 // ==================== CELL UPDATE TESTS ====================

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -894,6 +894,291 @@ fn test_add_consecutive_cells_correct_count() {
     assert_eq!(json3["total_cells"], 3);
 }
 
+// ==================== MULTI-CELL ADD TESTS (@@sentinel format) ====================
+
+#[test]
+fn test_add_multiple_cells_with_sentinels() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@code\nx = 1\n@@code\ny = 2\n@@code\nz = 3",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 3);
+    assert_eq!(json["total_cells"], 3);
+
+    let cells = json["cells"].as_array().unwrap();
+    assert_eq!(cells.len(), 3);
+    assert_eq!(cells[0]["index"], 0);
+    assert_eq!(cells[1]["index"], 1);
+    assert_eq!(cells[2]["index"], 2);
+    assert_eq!(cells[0]["cell_type"], "code");
+}
+
+#[test]
+fn test_add_multiple_cells_mixed_types() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@markdown\n# Title\n@@code\nx = 1\n@@raw\nraw stuff",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 3);
+
+    let cells = json["cells"].as_array().unwrap();
+    assert_eq!(cells[0]["cell_type"], "markdown");
+    assert_eq!(cells[1]["cell_type"], "code");
+    assert_eq!(cells[2]["cell_type"], "raw");
+
+    // Verify sources by reading the notebook
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(join_source(&nb_cells[0]["source"]), "# Title");
+    assert_eq!(join_source(&nb_cells[1]["source"]), "x = 1");
+    assert_eq!(join_source(&nb_cells[2]["source"]), "raw stuff");
+}
+
+#[test]
+fn test_add_multiple_cells_at_index() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("with_code.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@code\ninserted_1\n@@code\ninserted_2",
+            "--insert-at",
+            "1",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 2);
+    assert_eq!(json["total_cells"], 4); // 2 existing + 2 new
+
+    let cells = json["cells"].as_array().unwrap();
+    assert_eq!(cells[0]["index"], 1);
+    assert_eq!(cells[1]["index"], 2);
+
+    // Verify ordering by reading the notebook
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(nb_cells.len(), 4);
+    assert_eq!(join_source(&nb_cells[1]["source"]), "inserted_1");
+    assert_eq!(join_source(&nb_cells[2]["source"]), "inserted_2");
+}
+
+#[test]
+fn test_add_multiple_cells_after_cell_id() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("with_code.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@code\nafter_1\n@@markdown\nafter_2",
+            "--after",
+            "cell-1",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 2);
+
+    let cells = json["cells"].as_array().unwrap();
+    assert_eq!(cells[0]["index"], 1);
+    assert_eq!(cells[1]["index"], 2);
+
+    // Verify ordering
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(join_source(&nb_cells[1]["source"]), "after_1");
+    assert_eq!(join_source(&nb_cells[2]["source"]), "after_2");
+}
+
+#[test]
+fn test_add_multiple_cells_id_flag_rejected() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    env.run(&[
+        "cell",
+        "add",
+        nb_path.to_str().unwrap(),
+        "-s",
+        "@@code\na\n@@code\nb",
+        "--id",
+        "my-id",
+    ])
+    .assert_failure();
+}
+
+#[test]
+fn test_add_multiple_cells_unique_ids() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@code\ncell_a\n@@code\ncell_b\n@@code\ncell_c",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    let cells = json["cells"].as_array().unwrap();
+
+    // All cell IDs should be unique
+    let ids: Vec<&str> = cells
+        .iter()
+        .map(|c| c["cell_id"].as_str().unwrap())
+        .collect();
+    let unique_ids: std::collections::HashSet<&str> = ids.iter().cloned().collect();
+    assert_eq!(ids.len(), unique_ids.len(), "Cell IDs must be unique");
+}
+
+#[test]
+fn test_add_single_cell_backward_compat() {
+    // Source without sentinels uses --type flag and single-cell output format
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "hello",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    // Single-cell format has cell_id directly (not in a cells array)
+    assert!(json["cell_id"].is_string());
+    assert!(json["cell_type"].is_string());
+    assert!(json["index"].is_number());
+    assert!(json["total_cells"].is_number());
+    // Should NOT have cells_added or cells array
+    assert!(json["cells_added"].is_null());
+    assert!(json["cells"].is_null());
+}
+
+#[test]
+fn test_add_no_source_backward_compat() {
+    // When no -s is provided, should add a single empty cell (backward compat)
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&["cell", "add", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["index"], 0);
+    assert_eq!(json["total_cells"], 1);
+    // Single-cell format
+    assert!(json["cell_id"].is_string());
+}
+
+#[test]
+fn test_add_sentinel_multiline_source() {
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@code\ndef hello():\n    print('world')\n\nhello()\n@@markdown\n# Notes\nThis is a note.",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    assert_eq!(json["cells_added"], 2);
+
+    // Verify sources
+    let read_result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+    let nb_json = read_result.json_value();
+    let nb_cells = nb_json["cells"].as_array().unwrap();
+    assert_eq!(
+        join_source(&nb_cells[0]["source"]),
+        "def hello():\n    print('world')\n\nhello()"
+    );
+    assert_eq!(
+        join_source(&nb_cells[1]["source"]),
+        "# Notes\nThis is a note."
+    );
+}
+
+#[test]
+fn test_add_single_sentinel_still_uses_type() {
+    // A single @@code sentinel should produce a single-cell result format
+    let env = TestEnv::new();
+    let nb_path = env.copy_fixture("empty.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&[
+            "cell",
+            "add",
+            nb_path.to_str().unwrap(),
+            "-s",
+            "@@markdown\n# Just one cell",
+            "--json",
+        ])
+        .assert_success();
+
+    let json = result.json_value();
+    // Single-cell format
+    assert_eq!(json["cell_type"], "markdown");
+    assert!(json["cell_id"].is_string());
+}
+
 // ==================== CELL UPDATE TESTS ====================
 
 #[test]


### PR DESCRIPTION
Fixes #68 

The --source flag now accepts @@code, @@markdown, and @@raw on their own line as cell delimiters, allowing multiple cells of mixed types to be added in a single call. Without sentinels, behavior is unchanged.

- Parse sentinel-delimited source into typed cells in add_cell.rs
- Add parse_source_text() helper in common.rs
- Add ydoc_add_cells() for batch Y.js insertion in one connection
- Remove unused ydoc_add_cell() singular function
- Multi-cell JSON output uses cells_added/total_cells/cells array; single-cell output format preserved for backward compatibility
- 8 unit tests for sentinel parser, 11 integration tests
- Update notebook-cli skill docs with multi-cell add examples