### PR TITLE
Fix aarch64 musl CI: replace wget from musl.cc with cross

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -131,23 +131,23 @@ jobs:
       - name: Install cross-compilation tools (Linux ARM64 musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
-          # Install aarch64 musl cross-compiler
-          wget -q https://musl.cc/aarch64-linux-musl-cross.tgz
-          tar xzf aarch64-linux-musl-cross.tgz -C /opt
-          echo "/opt/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV
+          pip install ziglang
+          cargo install cargo-zigbuild --locked
+
+      - name: Build release binary (Linux ARM64 musl)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: cargo zigbuild --release --target ${{ matrix.target }}
 
       - name: Build release binary
+        if: matrix.target != 'aarch64-unknown-linux-musl'
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux ARM64 musl)
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: /opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+      - name: Strip binary (Linux musl)
+        if: matrix.os == 'ubuntu-latest'
+        run: llvm-strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
-      - name: Strip binary (other platforms)
-        if: matrix.os != 'windows-latest' && matrix.target != 'aarch64-unknown-linux-musl'
+      - name: Strip binary (macOS)
+        if: matrix.os == 'macos-latest'
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
       - name: Upload artifact

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CROSS_VERSION: v0.2.5
 
 jobs:
   create-tag:
@@ -119,8 +120,10 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+
+      - name: Add Rust target (native builds)
+        if: matrix.target != 'aarch64-unknown-linux-musl'
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install musl tools (Linux x86_64)
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -128,26 +131,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Install cross-compilation tools (Linux ARM64 musl)
+      - name: Install cross (Linux ARM64 musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |
-          pip install ziglang
-          cargo install cargo-zigbuild --locked
+          dir="$RUNNER_TEMP/cross-download"
+          mkdir "$dir"
+          echo "$dir" >> $GITHUB_PATH
+          cd "$dir"
+          curl -LO "https://github.com/cross-rs/cross/releases/download/${{ env.CROSS_VERSION }}/cross-x86_64-unknown-linux-musl.tar.gz"
+          tar xf cross-x86_64-unknown-linux-musl.tar.gz
 
       - name: Build release binary (Linux ARM64 musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo zigbuild --release --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Build release binary
         if: matrix.target != 'aarch64-unknown-linux-musl'
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux musl)
-        if: matrix.os == 'ubuntu-latest'
-        run: llvm-strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
-
-      - name: Strip binary (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Strip binary
+        if: matrix.os != 'windows-latest' && matrix.target != 'aarch64-unknown-linux-musl'
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
       - name: Upload artifact


### PR DESCRIPTION
## Problem

The `Build aarch64-unknown-linux-musl` job downloads an aarch64 musl cross-compiler from musl.cc via bare `wget` with no retries. This consistently fails in GitHub Actions with exit code 4 (network timeout), blocking releases. Example: https://github.com/jupyter-ai-contrib/nb-cli/actions/runs/24805176987

## Solution

Switch to [`cross`](https://github.com/cross-rs/cross) v0.2.5 — the industry-standard Docker-based Rust cross-compilation tool. No external CDN dependency: `cross` is downloaded from its own GitHub releases, which are reliable. Docker is pre-installed on `ubuntu-latest` runners.

This is the same approach used by ripgrep, fd, and yrs (a direct dependency of nb-cli). `cross` strips the binary inside the container, so no separate strip step is needed for the aarch64 target.

The output binary remains `aarch64-unknown-linux-musl` — fully static, no glibc dependency — preserving the goal from #70.

## Changes

- Pin `CROSS_VERSION: v0.2.5` in env for easy future updates
- Download `cross` from GitHub releases instead of compiling it
- `cross build` for aarch64-unknown-linux-musl; `cargo build` for all other targets
- Strip step skips aarch64 (cross handles it) and Windows; runs natively elsewhere
- Split toolchain install from `rustup target add` — host target registration is a no-op when cross builds inside Docker, so the condition is now explicit