### PR TITLE
Forward kernel.json env vars when spawning via uv/pixi

### DIFF
--- a/src/execution/local/executor.rs
+++ b/src/execution/local/executor.rs
@@ -313,6 +313,9 @@ impl ExecutionBackend for LocalExecutor {
                         OsStr::new(arg)
                     });
                 }
+                if let Some(env) = &kernel_spec.kernelspec.env {
+                    cmd.envs(env);
+                }
 
                 cmd
             }


### PR DESCRIPTION
When `--uv`/`--pixi` is used, `nb execute` builds the kernel launch command directly from `argv` in `kernel.json` instead of going through `runtimelib::KernelspecDir::command()`, which applies the `env` map from `kernel.json`. Kernels that rely on env vars (R: `R_LIBS_USER`, Julia: `JULIA_DEPOT_PATH`, custom kernels) launch without them. Most likely to hit in pixi projects where conda-based environments commonly host non-Python kernels.

To reproduce, add an env block to any `kernel.json` (e.g. `{"env": {"MY_VAR": "hello"}}`) and run `nb execute --uv`; the vars will be missing from the kernel process.

Fix: forward `kernel_spec.kernelspec.env` onto the command in the `Uv | Pixi` spawn arm (`src/execution/local/executor.rs`), mirroring what `KernelspecDir::command()` does for the `Direct` path.

## Testing

Create a uv project, install ipykernel, and add env var into the installed `kernel.json`. Execute a notebook that reads that var with `--uv` and confirm it prints the injected value (not `NOT_SET`).

```bash
mkdir /tmp/nb-env-test && cd /tmp/nb-env-test
uv init --bare --name env-test && uv add ipykernel
uv run python -m ipykernel install --sys-prefix --name env-test-kernel

KERNEL_DIR=$(uv run jupyter kernelspec list --json | \
  python3 -c "import sys,json; d=json.load(sys.stdin); \
  print(d['kernelspecs']['env-test-kernel']['resource_dir'])")
python3 -c "
import json, pathlib
p = pathlib.Path('$KERNEL_DIR/kernel.json')
k = json.loads(p.read_text())
k.setdefault('env', {})['NB_TEST_VAR'] = 'forwarded_correctly'
p.write_text(json.dumps(k, indent=1))
"

nb create test.ipynb --uv --kernel env-test-kernel
nb cell add test.ipynb --source "import os; print(os.environ.get('NB_TEST_VAR', 'NOT_SET'))"
nb execute test.ipynb --uv
# expect: forwarded_correctly  (before fix: NOT_SET)