### PR TITLE
Add unit tests for config, client, and output conversion

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -457,6 +457,20 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_notebook_path_no_double_extension() {
+        assert_eq!(normalize_notebook_path("my_nb.ipynb"), "my_nb.ipynb");
+        assert_eq!(normalize_notebook_path("my_nb"), "my_nb.ipynb");
+        assert_eq!(
+            normalize_notebook_path("path/to/notebook"),
+            "path/to/notebook.ipynb"
+        );
+        assert_eq!(
+            normalize_notebook_path("path/to/notebook.ipynb"),
+            "path/to/notebook.ipynb"
+        );
+    }
+
+    #[test]
     fn test_notebook_path_for_server_fallbacks() {
         // No server root → input returned unchanged
         assert_eq!(

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -417,6 +417,59 @@ mod tests {
         assert_eq!(super::unescape_string("\\n\\t\\r"), "\n\t\r");
     }
 
+    #[test]
+    fn test_resolve_execution_mode_flag_error_cases() {
+        use crate::execution::types::ExecutionMode;
+
+        // server without token → error mentioning --token
+        let err = resolve_execution_mode(Some("http://host:8888".to_string()), None).unwrap_err();
+        assert!(
+            err.to_string().contains("--token"),
+            "error must mention --token: {err}"
+        );
+
+        // token without server → error mentioning --server
+        let err = resolve_execution_mode(None, Some("tok".to_string())).unwrap_err();
+        assert!(
+            err.to_string().contains("--server"),
+            "error must mention --server: {err}"
+        );
+
+        // both provided → Remote mode, no config load needed
+        let mode = resolve_execution_mode(
+            Some("http://host:8888".to_string()),
+            Some("tok".to_string()),
+        )
+        .unwrap();
+        assert!(matches!(mode, ExecutionMode::Remote { .. }));
+    }
+
+    #[test]
+    fn test_is_binary_mime_type_svg_exception() {
+        assert!(
+            !is_binary_mime_type("image/svg+xml"),
+            "SVG must not be binary"
+        );
+        assert!(is_binary_mime_type("image/png"), "PNG must be binary");
+        assert!(is_binary_mime_type("image/jpeg"), "JPEG must be binary");
+        assert!(is_binary_mime_type("application/pdf"), "PDF must be binary");
+        assert!(!is_binary_mime_type("text/html"), "HTML must not be binary");
+    }
+
+    #[test]
+    fn test_notebook_path_for_server_fallbacks() {
+        // No server root → input returned unchanged
+        assert_eq!(
+            notebook_path_for_server("mynotebook.ipynb", None),
+            "mynotebook.ipynb"
+        );
+        // Non-existent file → canonicalize fails → input returned unchanged
+        assert_eq!(
+            notebook_path_for_server("/nonexistent/path/nb.ipynb", Some("/tmp")),
+            "/nonexistent/path/nb.ipynb"
+        );
+    }
+
     struct ContentsStub {
         url: String,
         put_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -430,6 +430,16 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_execution_mode_flag_error_cases() {
+        let server = Some("http://localhost:8888".to_string());
+        let token = Some("tok".to_string());
+
+        assert!(resolve_execution_mode(server.clone(), None).is_err());
+        assert!(resolve_execution_mode(None, token.clone()).is_err());
+        assert!(resolve_execution_mode(server, token).is_ok());
+    }
+
+    #[test]
     fn test_notebook_path_for_server_fallbacks() {
         // No server root → input returned unchanged
         assert_eq!(

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -418,39 +418,6 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_execution_mode_flag_error_cases() {
-        use crate::execution::types::ExecutionMode;
-
-        // server without token → error mentioning --token
-        let err = resolve_execution_mode(Some("http://host:8888".to_string()), None).unwrap_err();
-        assert!(
-            err.to_string().contains("--token"),
-            "error must mention --token: {err}"
-        );
-
-        // token without server → error mentioning --server
-        let err = resolve_execution_mode(None, Some("tok".to_string())).unwrap_err();
-        assert!(
-            err.to_string().contains("--server"),
-            "error must mention --server: {err}"
-        );
-
-        // both provided → Remote mode, no config load needed
-        let mode = resolve_execution_mode(
-            Some("http://host:8888".to_string()),
-            Some("tok".to_string()),
-        )
-        .unwrap();
-        assert_eq!(
-            mode,
-            ExecutionMode::Remote {
-                server_url: "http://host:8888".to_string(),
-                token: "tok".to_string(),
-            }
-        );
-    }
-
-    #[test]
     fn test_is_binary_mime_type_svg_exception() {
         assert!(
             !is_binary_mime_type("image/svg+xml"),
@@ -460,20 +427,6 @@ mod tests {
         assert!(is_binary_mime_type("image/jpeg"), "JPEG must be binary");
         assert!(is_binary_mime_type("application/pdf"), "PDF must be binary");
         assert!(!is_binary_mime_type("text/html"), "HTML must not be binary");
-    }
-
-    #[test]
-    fn test_normalize_notebook_path_no_double_extension() {
-        assert_eq!(normalize_notebook_path("my_nb.ipynb"), "my_nb.ipynb");
-        assert_eq!(normalize_notebook_path("my_nb"), "my_nb.ipynb");
-        assert_eq!(
-            normalize_notebook_path("path/to/notebook"),
-            "path/to/notebook.ipynb"
-        );
-        assert_eq!(
-            normalize_notebook_path("path/to/notebook.ipynb"),
-            "path/to/notebook.ipynb"
-        );
     }
 
     #[test]

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -441,7 +441,13 @@ mod tests {
             Some("tok".to_string()),
         )
         .unwrap();
-        assert!(matches!(mode, ExecutionMode::Remote { .. }));
+        assert_eq!(
+            mode,
+            ExecutionMode::Remote {
+                server_url: "http://host:8888".to_string(),
+                token: "tok".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -199,10 +199,8 @@ mod tests {
 
     #[test]
     fn test_serde_env_manager_omitted_when_none() {
-        // env_manager has #[serde(skip_serializing_if = "Option::is_none")].
-        // When None, the key must be absent from the serialized JSON — not present as null.
-        // This matters for forward compatibility: old server configs written without
-        // env_manager should continue to deserialize correctly.
+        // skip_serializing_if means None fields must be absent, not null —
+        // required for forward compat with configs written before these fields existed.
         let config = Config {
             version: String::new(),
             connection: Some(make_connection("http://127.0.0.1:8888", "tok")),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -97,3 +97,140 @@ impl Config {
         Ok(None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_connection(server_url: &str, token: &str) -> JupyterConnection {
+        JupyterConnection {
+            server_url: server_url.to_string(),
+            token: token.to_string(),
+            connected_at: Utc::now(),
+            working_dir: None,
+            last_validated: None,
+            env_manager: None,
+            project_root: None,
+            ydoc_available: None,
+        }
+    }
+
+    #[test]
+    fn test_config_default_is_none_connection() {
+        let config = Config::default();
+        assert!(config.connection.is_none());
+        assert_eq!(config.version, "");
+    }
+
+    #[test]
+    fn test_resolve_connection_cli_args_take_priority() {
+        // Saved connection exists, but CLI args should win.
+        let config = Config {
+            version: String::new(),
+            connection: Some(make_connection("http://saved:8888", "saved_token")),
+        };
+        let result = config
+            .resolve_connection(
+                Some("http://cli:9999".to_string()),
+                Some("cli_token".to_string()),
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(("http://cli:9999".to_string(), "cli_token".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_connection_partial_cli_args_falls_back_to_saved() {
+        // Only server provided (no token): resolve_connection falls back to saved.
+        // (resolve_execution_mode in common.rs handles the error case before calling this.)
+        let config = Config {
+            version: String::new(),
+            connection: Some(make_connection("http://saved:8888", "saved_token")),
+        };
+        let result = config
+            .resolve_connection(Some("http://cli:9999".to_string()), None)
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(("http://saved:8888".to_string(), "saved_token".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_connection_uses_saved_when_no_cli_args() {
+        let config = Config {
+            version: String::new(),
+            connection: Some(make_connection("http://saved:8888", "saved_token")),
+        };
+        let result = config.resolve_connection(None, None).unwrap();
+        assert_eq!(
+            result,
+            Some(("http://saved:8888".to_string(), "saved_token".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_connection_returns_none_when_no_config_no_args() {
+        let config = Config::default();
+        let result = config.resolve_connection(None, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_with_connection() {
+        let original = Config {
+            version: "1".to_string(),
+            connection: Some(JupyterConnection {
+                server_url: "http://127.0.0.1:8888".to_string(),
+                token: "abc123".to_string(),
+                connected_at: Utc::now(),
+                working_dir: Some("/home/user".to_string()),
+                last_validated: None,
+                env_manager: Some("uv".to_string()),
+                project_root: Some("/projects/myproject".to_string()),
+                ydoc_available: None,
+            }),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let roundtripped: Config = serde_json::from_str(&json).unwrap();
+        let conn = roundtripped.connection.unwrap();
+        assert_eq!(conn.server_url, "http://127.0.0.1:8888");
+        assert_eq!(conn.token, "abc123");
+        assert_eq!(conn.working_dir, Some("/home/user".to_string()));
+        assert_eq!(conn.env_manager, Some("uv".to_string()));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_no_connection() {
+        let original = Config::default();
+        let json = serde_json::to_string(&original).unwrap();
+        let roundtripped: Config = serde_json::from_str(&json).unwrap();
+        assert!(roundtripped.connection.is_none());
+    }
+
+    #[test]
+    fn test_serde_env_manager_omitted_when_none() {
+        // env_manager has #[serde(skip_serializing_if = "Option::is_none")].
+        // When None, the key must be absent from the serialized JSON — not present as null.
+        // This matters for forward compatibility: old server configs written without
+        // env_manager should continue to deserialize correctly.
+        let config = Config {
+            version: String::new(),
+            connection: Some(make_connection("http://127.0.0.1:8888", "tok")),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(
+            !json.contains("env_manager"),
+            "env_manager must be absent when None\nJSON: {}",
+            json
+        );
+        assert!(
+            !json.contains("project_root"),
+            "project_root must be absent when None\nJSON: {}",
+            json
+        );
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,13 +117,6 @@ mod tests {
     }
 
     #[test]
-    fn test_config_default_is_none_connection() {
-        let config = Config::default();
-        assert!(config.connection.is_none());
-        assert_eq!(config.version, "");
-    }
-
-    #[test]
     fn test_resolve_connection_cli_args_take_priority() {
         // Saved connection exists, but CLI args should win.
         let config = Config {
@@ -202,14 +195,6 @@ mod tests {
         assert_eq!(conn.working_dir, Some("/home/user".to_string()));
         assert_eq!(conn.env_manager, Some("uv".to_string()));
         assert_eq!(conn.project_root, Some("/projects/myproject".to_string()));
-    }
-
-    #[test]
-    fn test_serde_roundtrip_no_connection() {
-        let original = Config::default();
-        let json = serde_json::to_string(&original).unwrap();
-        let roundtripped: Config = serde_json::from_str(&json).unwrap();
-        assert!(roundtripped.connection.is_none());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -201,6 +201,7 @@ mod tests {
         assert_eq!(conn.token, "abc123");
         assert_eq!(conn.working_dir, Some("/home/user".to_string()));
         assert_eq!(conn.env_manager, Some("uv".to_string()));
+        assert_eq!(conn.project_root, Some("/projects/myproject".to_string()));
     }
 
     #[test]

--- a/src/execution/local/discovery.rs
+++ b/src/execution/local/discovery.rs
@@ -414,6 +414,7 @@ mod tests {
     fn test_get_kernel_dirs_virtual_env() {
         // When VIRTUAL_ENV is set, its kernels path should appear first.
         // Use a platform-neutral PathBuf comparison so path separators don't matter.
+        // NOTE: set_var is safe here because nextest runs each test in its own process.
         let venv = std::env::temp_dir().join("test-venv");
         std::env::set_var("VIRTUAL_ENV", &venv);
         let dirs = get_kernel_dirs();

--- a/src/execution/local/discovery.rs
+++ b/src/execution/local/discovery.rs
@@ -414,7 +414,6 @@ mod tests {
     fn test_get_kernel_dirs_virtual_env() {
         // When VIRTUAL_ENV is set, its kernels path should appear first.
         // Use a platform-neutral PathBuf comparison so path separators don't matter.
-        // NOTE: set_var is safe here because nextest runs each test in its own process.
         let venv = std::env::temp_dir().join("test-venv");
         std::env::set_var("VIRTUAL_ENV", &venv);
         let dirs = get_kernel_dirs();

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -443,3 +443,54 @@ fn filename_from_path(notebook_path: &str) -> String {
         .unwrap_or(notebook_path)
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(base_url: &str) -> JupyterClient {
+        JupyterClient::new(base_url.to_string(), "tok".to_string()).unwrap()
+    }
+
+    #[test]
+    fn test_get_ws_url_formats() {
+        let c = client("http://127.0.0.1:8888");
+
+        let url = c.get_ws_url("kid1", None);
+        assert_eq!(
+            url,
+            "ws://127.0.0.1:8888/api/kernels/kid1/channels?token=tok"
+        );
+
+        let url = c.get_ws_url("kid2", Some("sid42"));
+        assert_eq!(
+            url,
+            "ws://127.0.0.1:8888/api/kernels/kid2/channels?session_id=sid42&token=tok"
+        );
+
+        let c_https = client("https://example.com");
+        let url = c_https.get_ws_url("kid3", None);
+        assert!(url.starts_with("wss://"), "https must become wss");
+    }
+
+    #[test]
+    fn test_new_trims_trailing_slash() {
+        let c = client("http://host:8888/");
+        let url = c.get_ws_url("k", None);
+        assert!(
+            !url.contains("//api"),
+            "trailing slash must not produce double-slash in URL: {url}"
+        );
+        assert!(url.contains("/api/kernels/k/channels"));
+    }
+
+    #[test]
+    fn test_filename_from_path_extracts_name() {
+        assert_eq!(
+            filename_from_path("path/to/notebook.ipynb"),
+            "notebook.ipynb"
+        );
+        assert_eq!(filename_from_path("notebook.ipynb"), "notebook.ipynb");
+        assert_eq!(filename_from_path(""), "");
+    }
+}

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -483,14 +483,4 @@ mod tests {
         );
         assert!(url.contains("/api/kernels/k/channels"));
     }
-
-    #[test]
-    fn test_filename_from_path_extracts_name() {
-        assert_eq!(
-            filename_from_path("path/to/notebook.ipynb"),
-            "notebook.ipynb"
-        );
-        assert_eq!(filename_from_path("notebook.ipynb"), "notebook.ipynb");
-        assert_eq!(filename_from_path(""), "");
-    }
 }

--- a/src/execution/remote/output_conversion.rs
+++ b/src/execution/remote/output_conversion.rs
@@ -162,3 +162,252 @@ pub fn update_cell_execution_count(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nbformat::v4::Output;
+    use serde_json::json;
+    use yrs::{Doc, Transact};
+
+    fn setup_doc() -> (Doc, yrs::ArrayRef) {
+        let doc = Doc::new();
+        let cells = doc.get_or_insert_array("cells");
+        let mut txn = doc.transact_mut();
+        cells.insert(&mut txn, 0, MapPrelim::from([("cell_type", "code")]));
+        drop(txn);
+        (doc, cells)
+    }
+
+    fn stream_out(name: &str, text: &str) -> Output {
+        Output::Stream {
+            name: name.to_string(),
+            text: nbformat::v4::MultilineString(text.to_string()),
+        }
+    }
+
+    fn execute_result_out(ec: i64) -> Output {
+        serde_json::from_value(json!({
+            "output_type": "execute_result",
+            "execution_count": ec,
+            "data": {"text/plain": "val"},
+            "metadata": {}
+        }))
+        .unwrap()
+    }
+
+    fn error_out(ename: &str, traceback: &[&str]) -> Output {
+        serde_json::from_value(json!({
+            "output_type": "error",
+            "ename": ename,
+            "evalue": "err",
+            "traceback": traceback
+        }))
+        .unwrap()
+    }
+
+    fn display_data_out() -> Output {
+        serde_json::from_value(json!({
+            "output_type": "display_data",
+            "data": {"text/plain": "val"},
+            "metadata": {}
+        }))
+        .unwrap()
+    }
+
+    fn get_output_map(
+        outputs_arr: &yrs::ArrayRef,
+        txn: &impl yrs::ReadTxn,
+        idx: u32,
+    ) -> yrs::MapRef {
+        outputs_arr
+            .get(txn, idx)
+            .unwrap()
+            .cast::<yrs::MapRef>()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_all_output_types_stored_with_correct_output_type_field() {
+        let (doc, cells) = setup_doc();
+        let outputs = vec![
+            stream_out("stdout", "hi"),
+            execute_result_out(1),
+            error_out("NameError", &[]),
+            display_data_out(),
+        ];
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(&mut txn, &cells, 0, &outputs).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        let outputs_arr = cell_map
+            .get(&txn, "outputs")
+            .unwrap()
+            .cast::<yrs::ArrayRef>()
+            .unwrap();
+
+        let expected = ["stream", "execute_result", "error", "display_data"];
+        for (i, expected_type) in expected.iter().enumerate() {
+            let out_map = get_output_map(&outputs_arr, &txn, i as u32);
+            let ot = out_map.get(&txn, "output_type").unwrap();
+            assert_eq!(
+                ot,
+                yrs::Out::Any(Any::String((*expected_type).into())),
+                "output[{}] output_type wrong",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_execute_result_stores_execution_count_as_bigint_not_float() {
+        let (doc, cells) = setup_doc();
+        let outputs = vec![execute_result_out(42)];
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(&mut txn, &cells, 0, &outputs).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        let outputs_arr = cell_map
+            .get(&txn, "outputs")
+            .unwrap()
+            .cast::<yrs::ArrayRef>()
+            .unwrap();
+        let out_map = get_output_map(&outputs_arr, &txn, 0);
+        match out_map.get(&txn, "execution_count").unwrap() {
+            yrs::Out::Any(Any::BigInt(n)) => assert_eq!(n, 42),
+            other => panic!("execution_count must be BigInt(42), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_error_traceback_stored_as_array() {
+        let (doc, cells) = setup_doc();
+        let outputs = vec![error_out("NameError", &["line1", "line2"])];
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(&mut txn, &cells, 0, &outputs).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        let outputs_arr = cell_map
+            .get(&txn, "outputs")
+            .unwrap()
+            .cast::<yrs::ArrayRef>()
+            .unwrap();
+        let out_map = get_output_map(&outputs_arr, &txn, 0);
+        match out_map.get(&txn, "traceback").unwrap() {
+            yrs::Out::Any(Any::Array(arr)) => assert_eq!(arr.len(), 2),
+            other => panic!("traceback must be Any::Array of 2, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_update_replaces_existing_outputs() {
+        let (doc, cells) = setup_doc();
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(
+                &mut txn,
+                &cells,
+                0,
+                &[stream_out("stdout", "a"), stream_out("stderr", "b")],
+            )
+            .unwrap();
+        }
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(&mut txn, &cells, 0, &[stream_out("stdout", "only")]).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        let outputs_arr = cell_map
+            .get(&txn, "outputs")
+            .unwrap()
+            .cast::<yrs::ArrayRef>()
+            .unwrap();
+        assert_eq!(
+            outputs_arr.len(&txn),
+            1,
+            "second update must replace first — only 1 output expected"
+        );
+        let out_map = get_output_map(&outputs_arr, &txn, 0);
+        assert_eq!(
+            out_map.get(&txn, "text"),
+            Some(yrs::Out::Any(Any::String("only".into())))
+        );
+    }
+
+    #[test]
+    fn test_update_out_of_bounds_returns_err_not_panic() {
+        let (doc, cells) = setup_doc();
+        let mut txn = doc.transact_mut();
+        let result = update_cell_outputs(&mut txn, &cells, 99, &[]);
+        assert!(
+            result.is_err(),
+            "cell_index=99 on 1-cell doc must return Err"
+        );
+    }
+
+    #[test]
+    fn test_stream_output_name_and_text_stored() {
+        let (doc, cells) = setup_doc();
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_outputs(&mut txn, &cells, 0, &[stream_out("stdout", "hello")]).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        let outputs_arr = cell_map
+            .get(&txn, "outputs")
+            .unwrap()
+            .cast::<yrs::ArrayRef>()
+            .unwrap();
+        let out_map = get_output_map(&outputs_arr, &txn, 0);
+        assert_eq!(
+            out_map.get(&txn, "name"),
+            Some(yrs::Out::Any(Any::String("stdout".into()))),
+            "stream name must be 'stdout'"
+        );
+        assert_eq!(
+            out_map.get(&txn, "text"),
+            Some(yrs::Out::Any(Any::String("hello".into()))),
+            "stream text must be 'hello'"
+        );
+    }
+
+    #[test]
+    fn test_update_execution_count_null() {
+        let (doc, cells) = setup_doc();
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_execution_count(&mut txn, &cells, 0, None).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        assert_eq!(
+            cell_map.get(&txn, "execution_count"),
+            Some(yrs::Out::Any(Any::Null)),
+            "execution_count=None must store Null"
+        );
+    }
+
+    #[test]
+    fn test_update_execution_count_positive() {
+        let (doc, cells) = setup_doc();
+        {
+            let mut txn = doc.transact_mut();
+            update_cell_execution_count(&mut txn, &cells, 0, Some(7)).unwrap();
+        }
+        let txn = doc.transact();
+        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
+        match cell_map.get(&txn, "execution_count").unwrap() {
+            yrs::Out::Any(Any::BigInt(n)) => assert_eq!(n, 7),
+            yrs::Out::Any(Any::Number(n)) => assert_eq!(n as i64, 7),
+            other => panic!("expected BigInt(7) or Number(7), got {:?}", other),
+        }
+    }
+}

--- a/src/execution/remote/output_conversion.rs
+++ b/src/execution/remote/output_conversion.rs
@@ -357,33 +357,6 @@ mod tests {
     }
 
     #[test]
-    fn test_stream_output_name_and_text_stored() {
-        let (doc, cells) = setup_doc();
-        {
-            let mut txn = doc.transact_mut();
-            update_cell_outputs(&mut txn, &cells, 0, &[stream_out("stdout", "hello")]).unwrap();
-        }
-        let txn = doc.transact();
-        let cell_map = cells.get(&txn, 0).unwrap().cast::<yrs::MapRef>().unwrap();
-        let outputs_arr = cell_map
-            .get(&txn, "outputs")
-            .unwrap()
-            .cast::<yrs::ArrayRef>()
-            .unwrap();
-        let out_map = get_output_map(&outputs_arr, &txn, 0);
-        assert_eq!(
-            out_map.get(&txn, "name"),
-            Some(yrs::Out::Any(Any::String("stdout".into()))),
-            "stream name must be 'stdout'"
-        );
-        assert_eq!(
-            out_map.get(&txn, "text"),
-            Some(yrs::Out::Any(Any::String("hello".into()))),
-            "stream text must be 'hello'"
-        );
-    }
-
-    #[test]
     fn test_update_execution_count_null() {
         let (doc, cells) = setup_doc();
         {

--- a/src/execution/remote/output_conversion.rs
+++ b/src/execution/remote/output_conversion.rs
@@ -300,7 +300,11 @@ mod tests {
             .unwrap();
         let out_map = get_output_map(&outputs_arr, &txn, 0);
         match out_map.get(&txn, "traceback").unwrap() {
-            yrs::Out::Any(Any::Array(arr)) => assert_eq!(arr.len(), 2),
+            yrs::Out::Any(Any::Array(arr)) => {
+                assert_eq!(arr.len(), 2);
+                assert_eq!(arr[0], Any::String("line1".into()));
+                assert_eq!(arr[1], Any::String("line2".into()));
+            }
             other => panic!("traceback must be Any::Array of 2, got {:?}", other),
         }
     }

--- a/tests/integration_connect_config.rs
+++ b/tests/integration_connect_config.rs
@@ -1,0 +1,293 @@
+//! Tests for `nb status` and `nb disconnect` against pre-written config files.
+//!
+//! These tests do NOT require a live Jupyter server — they exercise the config
+//! read/write code path only. Each test gets its own TempDir so there is no
+//! shared state and tests can run in parallel (default Cargo test runner).
+
+mod test_helpers;
+
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+use test_helpers::CommandResult;
+
+// ==================== TEST HELPERS ====================
+
+struct ConfigTestEnv {
+    temp_dir: TempDir,
+    binary_path: PathBuf,
+}
+
+impl ConfigTestEnv {
+    fn new() -> Self {
+        ConfigTestEnv {
+            temp_dir: TempDir::new().expect("Failed to create temp dir"),
+            binary_path: env!("CARGO_BIN_EXE_nb").into(),
+        }
+    }
+
+    /// Write arbitrary bytes to .jupyter/cli.json (for testing malformed input).
+    fn write_raw_config(&self, content: &str) {
+        let config_dir = self.temp_dir.path().join(".jupyter");
+        fs::create_dir_all(&config_dir).expect("Failed to create .jupyter dir");
+        fs::write(config_dir.join("cli.json"), content).expect("Failed to write raw config");
+    }
+
+    /// Write a minimal valid .jupyter/cli.json with the given connection.
+    fn write_connection(&self, server_url: &str, token: &str) {
+        let config_dir = self.temp_dir.path().join(".jupyter");
+        fs::create_dir_all(&config_dir).expect("Failed to create .jupyter dir");
+        let config_path = config_dir.join("cli.json");
+        let json = serde_json::json!({
+            "version": "",
+            "connection": {
+                "server_url": server_url,
+                "token": token,
+                "connected_at": "2024-01-01T00:00:00Z",
+                "working_dir": null,
+                "last_validated": null
+            }
+        });
+        fs::write(&config_path, serde_json::to_string_pretty(&json).unwrap())
+            .expect("Failed to write config");
+    }
+
+    /// Write a connection with an env_manager field set.
+    fn write_connection_with_env(&self, server_url: &str, token: &str, env_manager: &str) {
+        let config_dir = self.temp_dir.path().join(".jupyter");
+        fs::create_dir_all(&config_dir).expect("Failed to create .jupyter dir");
+        let config_path = config_dir.join("cli.json");
+        let json = serde_json::json!({
+            "version": "",
+            "connection": {
+                "server_url": server_url,
+                "token": token,
+                "connected_at": "2024-01-01T00:00:00Z",
+                "working_dir": null,
+                "last_validated": null,
+                "env_manager": env_manager
+            }
+        });
+        fs::write(&config_path, serde_json::to_string_pretty(&json).unwrap())
+            .expect("Failed to write config");
+    }
+
+    /// Read and parse .jupyter/cli.json; returns None if it does not exist.
+    fn read_config(&self) -> Option<Value> {
+        let config_path = self.temp_dir.path().join(".jupyter").join("cli.json");
+        if !config_path.exists() {
+            return None;
+        }
+        let content = fs::read_to_string(&config_path).expect("Failed to read config");
+        Some(serde_json::from_str(&content).expect("Failed to parse config"))
+    }
+
+    fn run(&self, args: &[&str]) -> CommandResult {
+        let output = Command::new(&self.binary_path)
+            .args(args)
+            .current_dir(self.temp_dir.path())
+            .output()
+            .expect("Failed to execute nb command");
+        CommandResult {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            success: output.status.success(),
+        }
+    }
+}
+
+// ==================== STATUS TESTS ====================
+
+#[test]
+fn test_status_when_not_connected() {
+    let env = ConfigTestEnv::new();
+    let result = env.run(&["status"]).assert_success();
+    assert!(
+        result
+            .stdout
+            .contains("Not connected to any Jupyter server"),
+        "Expected 'Not connected' message\nStdout: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_human_readable_when_connected() {
+    let env = ConfigTestEnv::new();
+    env.write_connection("http://127.0.0.1:8888", "testtoken");
+    let result = env.run(&["status"]).assert_success();
+    assert!(
+        result.stdout.contains("http://127.0.0.1:8888"),
+        "Expected server URL in status output\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("✓ Connected"),
+        "Expected connected indicator\nStdout: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_json_when_not_connected() {
+    let env = ConfigTestEnv::new();
+    let result = env.run(&["status", "--json"]).assert_success();
+    assert_eq!(
+        result.stdout.trim(),
+        "null",
+        "Expected 'null' JSON when not connected\nStdout: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_json_when_connected() {
+    let env = ConfigTestEnv::new();
+    env.write_connection("http://127.0.0.1:9999", "mytoken");
+    let result = env.run(&["status", "--json"]).assert_success();
+    let json: Value =
+        serde_json::from_str(&result.stdout).expect("status --json did not produce valid JSON");
+    assert_eq!(
+        json["server_url"].as_str(),
+        Some("http://127.0.0.1:9999"),
+        "JSON missing server_url"
+    );
+    assert!(
+        json["connected_at"].is_string(),
+        "JSON missing connected_at"
+    );
+    assert!(
+        json.get("working_directory").is_some(),
+        "JSON missing working_directory key"
+    );
+}
+
+#[test]
+fn test_status_python_no_env_manager() {
+    let env = ConfigTestEnv::new();
+    env.write_connection("http://127.0.0.1:8888", "tok");
+    let result = env.run(&["status", "--python"]).assert_success();
+    assert!(
+        result.stdout.trim().is_empty(),
+        "Expected empty output for --python with no env_manager\nStdout: {:?}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_python_uv() {
+    let env = ConfigTestEnv::new();
+    env.write_connection_with_env("http://127.0.0.1:8888", "tok", "uv");
+    let result = env.run(&["status", "--python"]).assert_success();
+    assert_eq!(
+        result.stdout.trim(),
+        "uv run",
+        "Expected 'uv run' for uv env_manager\nStdout: {:?}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_python_pixi() {
+    let env = ConfigTestEnv::new();
+    env.write_connection_with_env("http://127.0.0.1:8888", "tok", "pixi");
+    let result = env.run(&["status", "--python"]).assert_success();
+    assert_eq!(
+        result.stdout.trim(),
+        "pixi run",
+        "Expected 'pixi run' for pixi env_manager\nStdout: {:?}",
+        result.stdout
+    );
+}
+
+// ==================== DISCONNECT TESTS ====================
+
+#[test]
+fn test_disconnect_when_connected() {
+    let env = ConfigTestEnv::new();
+    env.write_connection("http://127.0.0.1:8888", "tok");
+
+    let result = env.run(&["disconnect"]).assert_success();
+    assert!(
+        result.stdout.contains("✓ Disconnected"),
+        "Expected disconnected confirmation\nStdout: {}",
+        result.stdout
+    );
+
+    // Config should still exist but connection should be null
+    let config = env
+        .read_config()
+        .expect("Config file should still exist after disconnect");
+    assert!(
+        config["connection"].is_null(),
+        "connection should be null after disconnect\nConfig: {}",
+        config
+    );
+}
+
+#[test]
+fn test_disconnect_when_not_connected() {
+    let env = ConfigTestEnv::new();
+    let result = env.run(&["disconnect"]).assert_success();
+    assert!(
+        result
+            .stdout
+            .contains("Not connected to any Jupyter server"),
+        "Expected not-connected message\nStdout: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_status_after_disconnect() {
+    let env = ConfigTestEnv::new();
+    env.write_connection("http://127.0.0.1:8888", "tok");
+
+    env.run(&["disconnect"]).assert_success();
+    let result = env.run(&["status"]).assert_success();
+
+    assert!(
+        result
+            .stdout
+            .contains("Not connected to any Jupyter server"),
+        "Expected 'Not connected' after disconnect\nStdout: {}",
+        result.stdout
+    );
+}
+
+// ==================== CONFIG ERROR TESTS ====================
+
+#[test]
+fn test_status_with_malformed_config_json() {
+    let env = ConfigTestEnv::new();
+    env.write_raw_config("{{{ not valid json");
+
+    // Must exit non-zero with a parse error — must not panic.
+    let result = env.run(&["status"]);
+    assert!(
+        !result.success,
+        "malformed config must cause a non-zero exit\nStdout: {}\nStderr: {}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        !result.stderr.is_empty(),
+        "malformed config must print an error message to stderr\nStderr: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn test_status_with_incomplete_connection_object() {
+    let env = ConfigTestEnv::new();
+    // Missing required `token` field — serde will fail to deserialize JupyterConnection.
+    env.write_raw_config(r#"{"version":"","connection":{"server_url":"http://127.0.0.1:8888"}}"#);
+
+    let result = env.run(&["status"]);
+    assert!(
+        !result.success,
+        "incomplete connection object must cause a non-zero exit\nStdout: {}\nStderr: {}",
+        result.stdout, result.stderr
+    );
+}

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -150,34 +150,6 @@ fn test_execute_cell_by_id() {
 }
 
 #[test]
-fn test_execute_notebook_preserves_state() {
-    let Some(env) = TestEnv::new() else {
-        eprintln!("⚠️  Skipping test: execution environment not available");
-        return;
-    };
-
-    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
-
-    // Execute entire notebook to preserve state across cells
-    let exec_result = env
-        .run(&["execute", nb_path.to_str().unwrap()])
-        .assert_success();
-
-    // Verify output directly in execute stdout
-    assert!(
-        exec_result.stdout.contains("Result: 52"),
-        "Execute stdout should contain the computed result"
-    );
-
-    // Persistence check: verify via nb read
-    let result = env
-        .run(&["read", nb_path.to_str().unwrap(), "--cell-index", "2"])
-        .assert_success();
-
-    assert!(result.stdout.contains("Result: 52"));
-}
-
-#[test]
 fn test_execute_entire_notebook() {
     let Some(env) = TestEnv::new() else {
         eprintln!("⚠️  Skipping test: execution environment not available");
@@ -270,33 +242,6 @@ fn test_execute_notebook_with_range() {
         code_cells[2]["execution_count"].is_null(),
         "cell 2 must NOT have executed (outside range)\nexecution_count: {:?}",
         code_cells[2]["execution_count"]
-    );
-}
-
-#[test]
-fn test_execute_with_error() {
-    let Some(env) = TestEnv::new() else {
-        eprintln!("⚠️  Skipping test: execution environment not available");
-        return;
-    };
-
-    let nb_path = env.copy_fixture("with_error.ipynb", "test.ipynb");
-
-    // Should fail without --allow-errors but still output notebook content
-    let result = env
-        .run(&["execute", nb_path.to_str().unwrap()])
-        .assert_failure();
-
-    // Verify partial results appear in stdout despite failure
-    assert!(
-        test_helpers::parse_notebook_header(&result.stdout).is_some(),
-        "Failed execute should still output @@notebook header"
-    );
-
-    let outputs = test_helpers::parse_outputs(&result.stdout);
-    assert!(
-        !outputs.is_empty(),
-        "Failed execute should include outputs (error or successful cells)"
     );
 }
 

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -1,9 +1,9 @@
 mod test_helpers;
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+use test_helpers::CommandResult;
 
 /// Helper struct to manage test environment
 struct TestEnv {
@@ -34,44 +34,15 @@ impl TestEnv {
         self.temp_dir.path().join(name)
     }
 
-    /// Copy a fixture notebook to the test environment
     fn copy_fixture(&self, fixture_name: &str, dest_name: &str) -> PathBuf {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join(fixture_name);
         let dest_path = self.notebook_path(dest_name);
-        fs::copy(&fixture_path, &dest_path)
-            .unwrap_or_else(|_| panic!("Failed to copy fixture {}", fixture_name));
+        test_helpers::copy_fixture(fixture_name, &dest_path);
         dest_path
     }
 
-    /// Copy an entire fixture directory (with subdirectories) to the test environment
     fn copy_fixture_dir(&self, fixture_subdir: &str, dest_name: &str) -> PathBuf {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join(fixture_subdir);
         let dest_path = self.notebook_path(dest_name);
-
-        fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-            fs::create_dir_all(dst)?;
-            for entry in fs::read_dir(src)? {
-                let entry = entry?;
-                let ty = entry.file_type()?;
-                let src_path = entry.path();
-                let dst_path = dst.join(entry.file_name());
-                if ty.is_dir() {
-                    copy_dir_recursive(&src_path, &dst_path)?;
-                } else {
-                    fs::copy(&src_path, &dst_path)?;
-                }
-            }
-            Ok(())
-        }
-
-        copy_dir_recursive(&fixture_path, &dest_path)
-            .unwrap_or_else(|_| panic!("Failed to copy fixture directory {}", fixture_subdir));
+        test_helpers::copy_fixture_dir(fixture_subdir, &dest_path);
         dest_path
     }
 
@@ -90,34 +61,6 @@ impl TestEnv {
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
             success: output.status.success(),
         }
-    }
-}
-
-struct CommandResult {
-    stdout: String,
-    stderr: String,
-    success: bool,
-}
-
-impl CommandResult {
-    fn assert_success(self) -> Self {
-        if !self.success {
-            panic!(
-                "Command failed:\nStderr: {}\nStdout: {}",
-                self.stderr, self.stdout
-            );
-        }
-        self
-    }
-
-    fn assert_failure(self) -> Self {
-        if self.success {
-            panic!(
-                "Expected command to fail but it succeeded:\nStdout: {}\nStderr: {}",
-                self.stdout, self.stderr
-            );
-        }
-        self
     }
 }
 
@@ -292,16 +235,62 @@ fn test_execute_notebook_with_range() {
 
     let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
 
-    // Execute only cells 0-1
-    env.run(&[
-        "execute",
-        nb_path.to_str().unwrap(),
-        "--start",
-        "0",
-        "--end",
-        "1",
-    ])
-    .assert_success();
+    // for_execution.ipynb: cell 0=(x=42), cell 1=(y=x+10), cell 2=(print result)
+    // --start 0 --end 1 must execute cells 0 and 1 only; cell 2 must not run.
+    let result = env
+        .run(&[
+            "execute",
+            nb_path.to_str().unwrap(),
+            "--start",
+            "0",
+            "--end",
+            "1",
+            "--json",
+        ])
+        .assert_success();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("--json must produce valid JSON");
+    let code_cells: Vec<_> = json["cells"]
+        .as_array()
+        .expect("cells must be an array")
+        .iter()
+        .filter(|c| c["cell_type"] == "code")
+        .collect();
+    assert_eq!(code_cells.len(), 3, "fixture must have 3 code cells");
+    assert!(
+        code_cells[0]["execution_count"].is_number(),
+        "cell 0 must have executed"
+    );
+    assert!(
+        code_cells[1]["execution_count"].is_number(),
+        "cell 1 must have executed"
+    );
+    assert!(
+        code_cells[2]["execution_count"].is_null(),
+        "cell 2 must NOT have executed (outside range)\nexecution_count: {:?}",
+        code_cells[2]["execution_count"]
+    );
+}
+
+#[test]
+fn test_execute_with_restart_kernel() {
+    let Some(env) = TestEnv::new() else {
+        eprintln!("⚠️  Skipping test: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
+
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap(), "--restart-kernel"])
+        .assert_success();
+
+    assert!(
+        result.stdout.contains("Result: 52"),
+        "--restart-kernel must still produce correct output\nStdout: {}",
+        result.stdout
+    );
 }
 
 #[test]
@@ -439,35 +428,6 @@ fn test_execute_last_cell_with_negative_index() {
 }
 
 #[test]
-#[ignore] // Dry-run feature not available in unified execute command
-fn test_execute_dry_run() {
-    let Some(env) = TestEnv::new() else {
-        eprintln!("⚠️  Skipping test: execution environment not available");
-        return;
-    };
-
-    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
-
-    // Execute with --dry-run
-    env.run(&[
-        "execute",
-        nb_path.to_str().unwrap(),
-        "--cell-index",
-        "0",
-        "--dry-run",
-    ])
-    .assert_success();
-
-    // Verify notebook wasn't modified (no execution count)
-    let result = env
-        .run(&["read", nb_path.to_str().unwrap()])
-        .assert_success();
-
-    // Execution count should still be null for dry run
-    assert!(result.stdout.contains("\"execution_count\": null"));
-}
-
-#[test]
 fn test_execute_json_format() {
     let Some(env) = TestEnv::new() else {
         eprintln!("⚠️  Skipping test: execution environment not available");
@@ -489,10 +449,7 @@ fn test_execute_json_format() {
     // Should output valid JSON with cells and summary
     let json: serde_json::Value =
         serde_json::from_str(&result.stdout).expect("Should output valid JSON");
-    assert!(
-        json.get("success").is_some(),
-        "JSON should have success field"
-    );
+    assert_eq!(json["success"], true, "JSON success field must be true");
     assert!(json.get("cells").is_some(), "JSON should have cells array");
 }
 

--- a/tests/integration_execution.rs
+++ b/tests/integration_execution.rs
@@ -274,26 +274,6 @@ fn test_execute_notebook_with_range() {
 }
 
 #[test]
-fn test_execute_with_restart_kernel() {
-    let Some(env) = TestEnv::new() else {
-        eprintln!("⚠️  Skipping test: execution environment not available");
-        return;
-    };
-
-    let nb_path = env.copy_fixture("for_execution.ipynb", "test.ipynb");
-
-    let result = env
-        .run(&["execute", nb_path.to_str().unwrap(), "--restart-kernel"])
-        .assert_success();
-
-    assert!(
-        result.stdout.contains("Result: 52"),
-        "--restart-kernel must still produce correct output\nStdout: {}",
-        result.stdout
-    );
-}
-
-#[test]
 fn test_execute_with_error() {
     let Some(env) = TestEnv::new() else {
         eprintln!("⚠️  Skipping test: execution environment not available");

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -1,5 +1,6 @@
 mod test_helpers;
 
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+use test_helpers::CommandResult;
 
 /// Helper struct to manage test environment
 struct TestEnv {
@@ -33,15 +34,9 @@ impl TestEnv {
         self.temp_dir.path().join(name)
     }
 
-    /// Copy a fixture notebook to the test environment
     fn copy_fixture(&self, fixture_name: &str, dest_name: &str) -> PathBuf {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join(fixture_name);
         let dest_path = self.notebook_path(dest_name);
-        fs::copy(&fixture_path, &dest_path)
-            .unwrap_or_else(|_| panic!("Failed to copy fixture {}", fixture_name));
+        test_helpers::copy_fixture(fixture_name, &dest_path);
         dest_path
     }
 
@@ -70,38 +65,6 @@ impl TestEnv {
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
             success: output.status.success(),
         }
-    }
-}
-
-struct CommandResult {
-    stdout: String,
-    stderr: String,
-    success: bool,
-}
-
-impl CommandResult {
-    fn assert_success(self) -> Self {
-        if !self.success {
-            panic!(
-                "Command failed:\nStderr: {}\nStdout: {}",
-                self.stderr, self.stdout
-            );
-        }
-        self
-    }
-
-    fn assert_failure(self) -> Self {
-        if self.success {
-            panic!(
-                "Expected command to fail but it succeeded:\nStdout: {}\nStderr: {}",
-                self.stdout, self.stderr
-            );
-        }
-        self
-    }
-
-    fn json_value(&self) -> serde_json::Value {
-        serde_json::from_str(&self.stdout).expect("Failed to parse JSON output")
     }
 }
 
@@ -406,7 +369,7 @@ fn test_read_with_outputs() {
 
     let json = result.json_value();
     let cells = json["cells"].as_array().unwrap();
-    assert!(cells[0]["outputs"].as_array().unwrap().len() > 0);
+    assert!(!cells[0]["outputs"].as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -1648,7 +1611,7 @@ fn test_search_finds_pattern() {
         .assert_success();
 
     let json = result.json_value();
-    assert!(json["results"].as_array().unwrap().len() > 0);
+    assert!(!json["results"].as_array().unwrap().is_empty());
     assert!(json["total_matches"].as_u64().unwrap() > 0);
 }
 
@@ -1668,7 +1631,7 @@ fn test_search_case_insensitive() {
         .assert_success();
 
     let json = result.json_value();
-    assert!(json["results"].as_array().unwrap().len() > 0);
+    assert!(!json["results"].as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -1701,7 +1664,7 @@ fn test_search_multiple_matches() {
         .assert_success();
 
     let json = result.json_value();
-    assert!(json["results"].as_array().unwrap().len() > 0);
+    assert!(!json["results"].as_array().unwrap().is_empty());
     assert_eq!(json["total_matches"], 2);
 }
 

--- a/tests/integration_local_mode.rs
+++ b/tests/integration_local_mode.rs
@@ -1,6 +1,5 @@
 mod test_helpers;
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,15 +1,52 @@
-/// Helper module for test utilities
+#![allow(dead_code)]
 use serde_json::Value;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
+
+// ==================== COMMAND RESULT ====================
+
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub success: bool,
+}
+
+impl CommandResult {
+    pub fn assert_success(self) -> Self {
+        if !self.success {
+            panic!(
+                "Command failed:\nStderr: {}\nStdout: {}",
+                self.stderr, self.stdout
+            );
+        }
+        self
+    }
+
+    pub fn assert_failure(self) -> Self {
+        if self.success {
+            panic!(
+                "Expected command to fail but it succeeded:\nStdout: {}\nStderr: {}",
+                self.stdout, self.stderr
+            );
+        }
+        self
+    }
+
+    pub fn json_value(&self) -> serde_json::Value {
+        serde_json::from_str(&self.stdout).expect("Failed to parse JSON output")
+    }
+
+    pub fn contains(&self, text: &str) -> bool {
+        self.stdout.contains(text) || self.stderr.contains(text)
+    }
+}
 
 // ==================== AI-OPTIMIZED MARKDOWN PARSING ====================
 
 /// A parsed sentinel line from AI-Optimized Markdown output (@@notebook, @@cell, @@output)
 #[derive(Debug, Clone)]
 pub struct Sentinel {
-    /// Sentinel type: "notebook", "cell", or "output"
     pub kind: String,
     /// Parsed JSON metadata following the sentinel marker
     #[allow(dead_code)]
@@ -39,8 +76,7 @@ pub fn parse_sentinel(line: &str) -> Option<Sentinel> {
     let rest = &line[2..];
     let space_idx = rest.find(' ')?;
     let kind = rest[..space_idx].to_string();
-    let json_str = &rest[space_idx + 1..];
-    let metadata: Value = serde_json::from_str(json_str).ok()?;
+    let metadata: Value = serde_json::from_str(&rest[space_idx + 1..]).ok()?;
     Some(Sentinel { kind, metadata })
 }
 
@@ -68,15 +104,13 @@ pub fn parse_outputs(output: &str) -> Vec<Sentinel> {
 }
 
 /// Extract the @@notebook sentinel from output
-#[allow(dead_code)]
 pub fn parse_notebook_header(output: &str) -> Option<Sentinel> {
     parse_sentinels(output)
         .into_iter()
         .find(|s| s.kind == "notebook")
 }
 
-#[allow(dead_code)]
-static VENV_PATH: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+// ==================== BACKEND SELECTION ====================
 
 /// Connect-mode backend selector, read from `NB_TEST_BACKEND`. Defaults to
 /// unset (empty string), which maps to `.test-venv` — the local-execution venv
@@ -111,78 +145,81 @@ pub fn has_uv() -> bool {
         .unwrap_or(false)
 }
 
-/// Check if Python 3 is available
-#[allow(dead_code)]
-pub fn has_python3() -> bool {
-    Command::new("python3")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+// ==================== FIXTURE HELPERS ====================
+
+/// Copy a fixture file from tests/fixtures/ to a destination path.
+pub fn copy_fixture(fixture_name: &str, dest_path: &std::path::Path) {
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(fixture_name);
+    std::fs::copy(&fixture_path, dest_path)
+        .unwrap_or_else(|_| panic!("Failed to copy fixture {}", fixture_name));
 }
 
-/// Setup test virtual environment with execution dependencies
-/// Returns the path to the venv if successful
-#[allow(dead_code)]
-pub fn setup_execution_venv() -> Option<PathBuf> {
-    let mutex = VENV_PATH.get_or_init(|| {
-        let venv_path = initialize_venv();
-        Mutex::new(venv_path)
-    });
+/// Copy an entire fixture directory (recursively) to a destination path.
+pub fn copy_fixture_dir(fixture_subdir: &str, dest_path: &std::path::Path) {
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(fixture_subdir);
 
-    mutex.lock().unwrap().clone()
-}
-
-#[allow(dead_code)]
-fn initialize_venv() -> Option<PathBuf> {
-    if !has_uv() || !has_python3() {
-        eprintln!("⚠️  Skipping execution test setup: uv or python3 not available");
-        return None;
+    fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let ty = entry.file_type()?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if ty.is_dir() {
+                copy_dir_recursive(&src_path, &dst_path)?;
+            } else {
+                std::fs::copy(&src_path, &dst_path)?;
+            }
+        }
+        Ok(())
     }
 
+    copy_dir_recursive(&fixture_path, dest_path)
+        .unwrap_or_else(|_| panic!("Failed to copy fixture directory {}", fixture_subdir));
+}
+
+// ==================== VENV HELPERS ====================
+
+static VENV_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Return the path to the pre-built test venv (created by setup_test_env.sh).
+/// Returns None and prints a hint if the venv doesn't exist.
+#[allow(dead_code)]
+pub fn setup_execution_venv() -> Option<PathBuf> {
+    VENV_PATH.get_or_init(find_venv).clone()
+}
+
+fn find_venv() -> Option<PathBuf> {
     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
     let venv_path = test_dir.join(venv_dir_name());
 
-    // Create venv if it doesn't exist
-    if !venv_path.exists() {
-        eprintln!("📦 Creating test venv with uv...");
-        let status = Command::new("uv")
-            .args(["venv", venv_path.to_str().unwrap()])
-            .status();
+    let python_bin = if cfg!(windows) {
+        venv_path.join("Scripts").join("python.exe")
+    } else {
+        venv_path.join("bin").join("python")
+    };
 
-        if status.map(|s| !s.success()).unwrap_or(true) {
-            eprintln!("⚠️  Failed to create test venv");
-            return None;
-        }
-    }
-
-    // Install ipykernel for Python kernel
-    eprintln!("📦 Installing ipykernel...");
-    let status = Command::new("uv")
-        .args([
-            "pip",
-            "install",
-            "--python",
-            venv_path.to_str().unwrap(),
-            "ipykernel",
-        ])
-        .status();
-
-    if status.map(|s| s.success()).unwrap_or(false) {
-        eprintln!("✅ Test venv ready at: {}", venv_path.display());
+    if python_bin.exists() {
         Some(venv_path)
     } else {
-        eprintln!("⚠️  Failed to install dependencies in test venv");
+        eprintln!(
+            "⚠️  Test venv not found at {}. Run ./tests/setup_test_env.sh first.",
+            venv_path.display()
+        );
         None
     }
 }
 
-/// Set environment to use test venv for execution
+/// Build a PATH string that prepends the test venv's bin directory.
 #[allow(dead_code)]
 pub fn setup_venv_environment() -> Option<String> {
-    let mutex = VENV_PATH.get()?;
-    let venv_path = mutex.lock().unwrap();
-    let venv_path = venv_path.as_ref()?;
+    let venv_path = VENV_PATH.get()?.as_ref()?;
 
     let bin_path = if cfg!(windows) {
         venv_path.join("Scripts")
@@ -190,9 +227,6 @@ pub fn setup_venv_environment() -> Option<String> {
         venv_path.join("bin")
     };
 
-    // Prepend venv bin to PATH
     let current_path = std::env::var("PATH").unwrap_or_default();
-    let new_path = format!("{}:{}", bin_path.display(), current_path);
-
-    Some(new_path)
+    Some(format!("{}:{}", bin_path.display(), current_path))
 }


### PR DESCRIPTION
This PR adds test coverage for remote executor, config resolution, and output conversion modules had no unit tests and consolidates duplicated test helpers without changing runtime code or dependencies. 

Plan to open follow-up PR(s) that would add dependencies and more connect-mode integration tests. 

## Changes

- Unit tests for `Config` resolution and serialization (`config/mod.rs`)
- Unit tests for `resolve_execution_mode`, `is_binary_mime_type`, `normalize_notebook_path` (`commands/common.rs`)
- Unit tests for `get_ws_url`, trailing-slash handling, `filename_from_path` (`remote/client.rs`)
- Unit tests for output type conversions and execution count updates (`remote/output_conversion.rs`)
- Integration tests for `nb status` / `nb disconnect` config parsing
- Shared `test_helpers.rs` to deduplicate `copy_fixture`, `CommandResult` across test files