### PR TITLE
Read notebooks from server in remote mode

### DIFF
--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -259,8 +259,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook from server
-    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
+    // Read notebook from server (reuse the server-relative path)
+    let notebook = common::read_notebook_remote(&server_url, &token, &notebook_server_path).await?;
 
     // Parse source content into cells
     let raw_text = common::parse_source_text(&args.source)?;

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -245,8 +245,10 @@ async fn execute_with_realtime(
 ) -> Result<()> {
     use crate::execution::remote::ydoc_notebook_ops;
 
-    let (server_url, token) = match mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => (server_url, token),
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
         _ => bail!("Expected remote execution mode"),
     };
 
@@ -257,8 +259,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook to calculate insertion index and create cells
-    let notebook = notebook::read_notebook(&file_path).context("Failed to read notebook")?;
+    // Read notebook from server
+    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
 
     // Parse source content into cells
     let raw_text = common::parse_source_text(&args.source)?;

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -268,21 +268,22 @@ pub fn resolve_server_root() -> Option<String> {
 }
 
 /// Read a notebook from a Jupyter Server via the Contents API.
+///
+/// `server_path` must be the notebook path relative to the server root
+/// (as computed by `notebook_path_for_server`).
 pub async fn read_notebook_remote(
     server_url: &str,
     token: &str,
-    file_path: &str,
+    server_path: &str,
 ) -> Result<nbformat::v4::Notebook> {
-    let server_root = resolve_server_root();
-    let server_path = notebook_path_for_server(file_path, server_root.as_deref());
     let client = crate::execution::remote::client::JupyterClient::new(
         server_url.to_string(),
         token.to_string(),
     )?;
     client
-        .get_notebook(&server_path)
+        .get_notebook(server_path)
         .await
-        .with_context(|| format!("Failed to read notebook '{}' from server", file_path))
+        .with_context(|| format!("Failed to read notebook '{}' from server", server_path))
 }
 
 /// Compute a notebook path relative to the Jupyter server root.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -267,6 +267,24 @@ pub fn resolve_server_root() -> Option<String> {
         .and_then(|c| c.working_dir)
 }
 
+/// Read a notebook from a Jupyter Server via the Contents API.
+pub async fn read_notebook_remote(
+    server_url: &str,
+    token: &str,
+    file_path: &str,
+) -> Result<nbformat::v4::Notebook> {
+    let server_root = resolve_server_root();
+    let server_path = notebook_path_for_server(file_path, server_root.as_deref());
+    let client = crate::execution::remote::client::JupyterClient::new(
+        server_url.to_string(),
+        token.to_string(),
+    )?;
+    client
+        .get_notebook(&server_path)
+        .await
+        .with_context(|| format!("Failed to read notebook '{}' from server", file_path))
+}
+
 /// Compute a notebook path relative to the Jupyter server root.
 ///
 /// The Jupyter Server identifies notebooks by their path relative to the

--- a/src/commands/create_notebook.rs
+++ b/src/commands/create_notebook.rs
@@ -1,4 +1,4 @@
-use crate::commands::common::OutputFormat;
+use crate::commands::common::{self, OutputFormat};
 use crate::commands::env_manager::EnvConfig;
 use crate::execution::local::discovery::find_kernel;
 use crate::notebook;
@@ -89,8 +89,28 @@ pub fn execute(args: CreateArgs) -> Result<()> {
     // Create notebook with specified kernel
     let notebook = create_notebook(&args)?;
 
-    // Write notebook to file
-    notebook::write_notebook_atomic(&path, &notebook).context("Failed to write notebook")?;
+    // Write notebook to appropriate destination
+    let mode = common::resolve_execution_mode(None, None)?;
+    match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            let server_root = common::resolve_server_root();
+            let server_path = common::notebook_path_for_server(&path, server_root.as_deref());
+            let client = crate::execution::remote::client::JupyterClient::new(
+                server_url.clone(),
+                token.clone(),
+            )?;
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime
+                .block_on(client.save_notebook(&server_path, &notebook))
+                .context("Failed to create notebook on server")?;
+        }
+        crate::execution::types::ExecutionMode::Local => {
+            notebook::write_notebook_atomic(&path, &notebook)
+                .context("Failed to write notebook")?;
+        }
+    }
 
     // Output result
     let result = CreateResult {

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -81,8 +81,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook from server
-    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
+    // Read notebook from server (reuse the server-relative path)
+    let notebook = common::read_notebook_remote(&server_url, &token, &notebook_server_path).await?;
 
     // Collect indices to delete
     let mut indices_to_delete: HashSet<usize> = HashSet::new();

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -67,8 +67,10 @@ async fn execute_with_realtime(
 ) -> Result<()> {
     use crate::execution::remote::ydoc_notebook_ops;
 
-    let (server_url, token) = match mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => (server_url, token),
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
         _ => bail!("Expected remote execution mode"),
     };
 
@@ -79,8 +81,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook to calculate which cells to delete
-    let notebook = notebook::read_notebook(&file_path).context("Failed to read notebook")?;
+    // Read notebook from server
+    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
 
     // Collect indices to delete
     let mut indices_to_delete: HashSet<usize> = HashSet::new();

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -122,7 +122,12 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // Read notebook from the appropriate source
     let mut notebook = match &mode {
         ExecutionMode::Remote { server_url, token } => {
-            common::read_notebook_remote(server_url, token, server_path.as_deref().expect("set for Remote mode")).await?
+            common::read_notebook_remote(
+                server_url,
+                token,
+                server_path.as_deref().expect("set for Remote mode"),
+            )
+            .await?
         }
         ExecutionMode::Local => read_notebook(&file_path).context("Failed to read notebook")?,
     };

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -122,7 +122,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // Read notebook from the appropriate source
     let mut notebook = match &mode {
         ExecutionMode::Remote { server_url, token } => {
-            common::read_notebook_remote(server_url, token, server_path.as_deref().unwrap()).await?
+            common::read_notebook_remote(server_url, token, server_path.as_deref().expect("set for Remote mode")).await?
         }
         ExecutionMode::Local => read_notebook(&file_path).context("Failed to read notebook")?,
     };
@@ -167,7 +167,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // For remote mode, reuse the pre-computed server-relative path.
     // For local mode, use absolute path for working directory determination.
     let notebook_identifier = match &mode {
-        ExecutionMode::Remote { .. } => server_path.clone().unwrap(),
+        ExecutionMode::Remote { .. } => server_path.unwrap(),
         ExecutionMode::Local => {
             let abs =
                 std::fs::canonicalize(&file_path).context("Failed to resolve notebook path")?;

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -107,10 +107,22 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     let mode =
         crate::commands::common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
+    // For remote mode, compute the server-relative path once and reuse it
+    // for both the Contents API read and the session identifier.
+    let server_path = if matches!(mode, ExecutionMode::Remote { .. }) {
+        let server_root = common::resolve_server_root();
+        Some(common::notebook_path_for_server(
+            &file_path,
+            server_root.as_deref(),
+        ))
+    } else {
+        None
+    };
+
     // Read notebook from the appropriate source
     let mut notebook = match &mode {
         ExecutionMode::Remote { server_url, token } => {
-            common::read_notebook_remote(server_url, token, &file_path).await?
+            common::read_notebook_remote(server_url, token, server_path.as_deref().unwrap()).await?
         }
         ExecutionMode::Local => read_notebook(&file_path).context("Failed to read notebook")?,
     };
@@ -152,13 +164,10 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         .as_ref()
         .map(|ks| ks.name.as_str());
 
-    // For remote mode, compute path relative to server root for session identity.
+    // For remote mode, reuse the pre-computed server-relative path.
     // For local mode, use absolute path for working directory determination.
     let notebook_identifier = match &mode {
-        ExecutionMode::Remote { .. } => {
-            let server_root = common::resolve_server_root();
-            common::notebook_path_for_server(&file_path, server_root.as_deref())
-        }
+        ExecutionMode::Remote { .. } => server_path.clone().unwrap(),
         ExecutionMode::Local => {
             let abs =
                 std::fs::canonicalize(&file_path).context("Failed to resolve notebook path")?;

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -101,21 +101,28 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         None
     };
 
-    // Read notebook
     let file_path = common::normalize_notebook_path(&args.file);
-    let mut notebook = read_notebook(&file_path).context("Failed to read notebook")?;
+
+    // Determine execution mode before reading — remote mode reads from server
+    let mode =
+        crate::commands::common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
+
+    // Read notebook from the appropriate source
+    let mut notebook = match &mode {
+        ExecutionMode::Remote { server_url, token } => {
+            common::read_notebook_remote(server_url, token, &file_path).await?
+        }
+        ExecutionMode::Local => read_notebook(&file_path).context("Failed to read notebook")?,
+    };
 
     // Determine cell range
     let (start_idx, end_idx) = if let Some(ref cell_id) = args.cell {
-        // Execute specific cell by ID
         let (idx, _) = crate::commands::common::find_cell_by_id(&notebook.cells, cell_id)?;
         (idx, idx)
     } else if let Some(cell_index) = args.cell_index {
-        // Execute specific cell by index
         let idx = crate::commands::common::normalize_index(cell_index, notebook.cells.len())?;
         (idx, idx)
     } else {
-        // Execute range or all cells
         let start = if let Some(start) = args.start {
             crate::commands::common::normalize_index(start, notebook.cells.len())?
         } else {
@@ -139,35 +146,27 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         );
     }
 
-    // Determine execution mode
-    let mode =
-        crate::commands::common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
-
-    // Get kernel from notebook metadata if not specified
     let notebook_kernel = notebook
         .metadata
         .kernelspec
         .as_ref()
         .map(|ks| ks.name.as_str());
 
-    // Get absolute path to notebook for working directory determination
-    let notebook_path_abs =
-        std::fs::canonicalize(&file_path).context("Failed to resolve notebook path")?;
-    let notebook_path_str = notebook_path_abs
-        .to_str()
-        .context("Notebook path contains invalid UTF-8")?
-        .to_string();
-
-    // For remote mode, compute path relative to server root so that
-    // notebooks with the same name in different directories get distinct sessions.
-    let notebook_identifier =
-        if matches!(mode, crate::execution::types::ExecutionMode::Remote { .. }) {
+    // For remote mode, compute path relative to server root for session identity.
+    // For local mode, use absolute path for working directory determination.
+    let notebook_identifier = match &mode {
+        ExecutionMode::Remote { .. } => {
             let server_root = common::resolve_server_root();
             common::notebook_path_for_server(&file_path, server_root.as_deref())
-        } else {
-            // For local mode, use full absolute path
-            notebook_path_str.clone()
-        };
+        }
+        ExecutionMode::Local => {
+            let abs = std::fs::canonicalize(&file_path)
+                .context("Failed to resolve notebook path")?;
+            abs.to_str()
+                .context("Notebook path contains invalid UTF-8")?
+                .to_string()
+        }
+    };
 
     // Create execution config
     let config = ExecutionConfig {

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -160,8 +160,8 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
             common::notebook_path_for_server(&file_path, server_root.as_deref())
         }
         ExecutionMode::Local => {
-            let abs = std::fs::canonicalize(&file_path)
-                .context("Failed to resolve notebook path")?;
+            let abs =
+                std::fs::canonicalize(&file_path).context("Failed to resolve notebook path")?;
             abs.to_str()
                 .context("Notebook path contains invalid UTF-8")?
                 .to_string()

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -47,7 +47,24 @@ pub struct ReadArgs {
 
 pub fn execute(args: ReadArgs) -> Result<()> {
     let file_path = common::normalize_notebook_path(&args.file);
-    let notebook = notebook::read_notebook(&file_path)?;
+
+    // Read from server when connected, otherwise from local filesystem
+    let mode = common::resolve_execution_mode(None, None)?;
+    let notebook = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            let server_root = common::resolve_server_root();
+            let server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime.block_on(common::read_notebook_remote(
+                server_url,
+                token,
+                &server_path,
+            ))?
+        }
+        crate::execution::types::ExecutionMode::Local => notebook::read_notebook(&file_path)?,
+    };
 
     // Determine format: markdown (default) or JSON
     let format = if args.json {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -99,9 +99,6 @@ pub fn execute(args: SearchArgs) -> Result<()> {
     // Normalize notebook path
     let file_path = common::normalize_notebook_path(&args.file);
 
-    // Phase 1: Text pre-filter - quick scan of raw file
-    let file_content = fs::read_to_string(&file_path)?;
-
     // Build regex pattern with case sensitivity
     let pattern = if args.ignore_case {
         format!("(?i){}", regex::escape(pattern_str))
@@ -111,14 +108,31 @@ pub fn execute(args: SearchArgs) -> Result<()> {
 
     let re = Regex::new(&pattern)?;
 
-    // Early exit if pattern not found in raw text
-    if !re.is_match(&file_content) {
-        print_empty_results(&args)?;
-        return Ok(());
-    }
-
-    // Phase 2: Parse and extract structured matches
-    let notebook = notebook::read_notebook(&file_path)?;
+    // Read notebook from server when connected, otherwise from local filesystem
+    let mode = common::resolve_execution_mode(None, None)?;
+    let notebook = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            let server_root = common::resolve_server_root();
+            let server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime.block_on(common::read_notebook_remote(
+                server_url,
+                token,
+                &server_path,
+            ))?
+        }
+        crate::execution::types::ExecutionMode::Local => {
+            // Phase 1: Text pre-filter - quick scan of raw file
+            let file_content = fs::read_to_string(&file_path)?;
+            if !re.is_match(&file_content) {
+                print_empty_results(&args)?;
+                return Ok(());
+            }
+            notebook::read_notebook(&file_path)?
+        }
+    };
     let mut results = Vec::new();
 
     for (index, cell) in notebook.cells.iter().enumerate() {
@@ -171,7 +185,24 @@ pub fn execute(args: SearchArgs) -> Result<()> {
 
 fn execute_with_errors(args: &SearchArgs) -> Result<()> {
     let file_path = common::normalize_notebook_path(&args.file);
-    let notebook = notebook::read_notebook(&file_path)?;
+
+    // Read notebook from server when connected, otherwise from local filesystem
+    let mode = common::resolve_execution_mode(None, None)?;
+    let notebook = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            let server_root = common::resolve_server_root();
+            let server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime.block_on(common::read_notebook_remote(
+                server_url,
+                token,
+                &server_path,
+            ))?
+        }
+        crate::execution::types::ExecutionMode::Local => notebook::read_notebook(&file_path)?,
+    };
     let mut results = Vec::new();
 
     // Build regex if pattern is provided

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -107,8 +107,10 @@ async fn execute_with_realtime(
 ) -> Result<()> {
     use crate::execution::remote::ydoc_notebook_ops;
 
-    let (server_url, token) = match mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => (server_url, token),
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
         _ => bail!("Expected remote execution mode"),
     };
 
@@ -119,8 +121,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook to find the cell
-    let notebook = notebook::read_notebook(&file_path).context("Failed to read notebook")?;
+    // Read notebook from server
+    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
 
     // Find the target cell
     let (index, cell_id) = if let Some(ref id) = args.cell {

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -121,8 +121,8 @@ async fn execute_with_realtime(
     let server_root = common::resolve_server_root();
     let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
 
-    // Read notebook from server
-    let notebook = common::read_notebook_remote(&server_url, &token, &file_path).await?;
+    // Read notebook from server (reuse the server-relative path)
+    let notebook = common::read_notebook_remote(&server_url, &token, &notebook_server_path).await?;
 
     // Find the target cell
     let (index, cell_id) = if let Some(ref id) = args.cell {

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -302,17 +302,33 @@ impl JupyterClient {
         Ok(())
     }
 
+    fn contents_url(&self, path: &str) -> Result<String> {
+        let mut url = url::Url::parse(&self.base_url).context("Invalid server URL")?;
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| anyhow::anyhow!("Server URL cannot be a base"))?;
+            segments.push("api").push("contents");
+            for part in path.split('/') {
+                if !part.is_empty() {
+                    segments.push(part);
+                }
+            }
+        }
+        Ok(url.to_string())
+    }
+
     /// Read a notebook from the server via the Contents API.
     pub async fn get_notebook(&self, path: &str) -> Result<nbformat::v4::Notebook> {
-        let url = format!("{}/api/contents/{}", self.base_url, path);
+        let url = self.contents_url(path)?;
 
         let response = self
             .client
             .get(&url)
             .query(&[
-                ("token", &self.token),
-                ("content", &"1".to_string()),
-                ("type", &"notebook".to_string()),
+                ("token", self.token.as_str()),
+                ("content", "1"),
+                ("type", "notebook"),
             ])
             .send()
             .await
@@ -345,7 +361,7 @@ impl JupyterClient {
     /// Save a notebook to the server
     #[allow(dead_code)]
     pub async fn save_notebook(&self, path: &str, notebook: &nbformat::v4::Notebook) -> Result<()> {
-        let url = format!("{}/api/contents/{}", self.base_url, path);
+        let url = self.contents_url(path)?;
 
         let payload = serde_json::json!({
             "type": "notebook",

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -302,6 +302,42 @@ impl JupyterClient {
         Ok(())
     }
 
+    /// Read a notebook from the server via the Contents API.
+    pub async fn get_notebook(&self, path: &str) -> Result<nbformat::v4::Notebook> {
+        let url = format!("{}/api/contents/{}", self.base_url, path);
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("token", &self.token), ("content", &"1".to_string()), ("type", &"notebook".to_string())])
+            .send()
+            .await
+            .context("Failed to fetch notebook from server")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Failed to fetch notebook: HTTP {} - {}", status, text);
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse Contents API response")?;
+
+        let content = body
+            .get("content")
+            .context("Contents API response missing 'content' field")?;
+
+        let nb = nbformat::parse_notebook(&content.to_string())
+            .context("Failed to parse notebook from server")?;
+
+        match nb {
+            nbformat::Notebook::V4(notebook) => Ok(notebook),
+            _ => anyhow::bail!("Only nbformat v4 notebooks are supported"),
+        }
+    }
+
     /// Save a notebook to the server
     #[allow(dead_code)]
     pub async fn save_notebook(&self, path: &str, notebook: &nbformat::v4::Notebook) -> Result<()> {

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -347,15 +347,11 @@ impl JupyterClient {
 
         let content = body
             .get("content")
+            .cloned()
             .context("Contents API response missing 'content' field")?;
 
-        let nb = nbformat::parse_notebook(&content.to_string())
-            .context("Failed to parse notebook from server")?;
-
-        match nb {
-            nbformat::Notebook::V4(notebook) => Ok(notebook),
-            _ => anyhow::bail!("Only nbformat v4 notebooks are supported"),
-        }
+        serde_json::from_value::<nbformat::v4::Notebook>(content)
+            .context("Failed to parse notebook from server (expected nbformat v4)")
     }
 
     /// Save a notebook to the server

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -309,7 +309,11 @@ impl JupyterClient {
         let response = self
             .client
             .get(&url)
-            .query(&[("token", &self.token), ("content", &"1".to_string()), ("type", &"notebook".to_string())])
+            .query(&[
+                ("token", &self.token),
+                ("content", &"1".to_string()),
+                ("type", &"notebook".to_string()),
+            ])
             .send()
             .await
             .context("Failed to fetch notebook from server")?;

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -372,7 +372,7 @@ impl JupyterClient {
         let response = self
             .client
             .put(&url)
-            .query(&[("token", &self.token)])
+            .query(&[("token", self.token.as_str())])
             .json(&payload)
             .send()
             .await

--- a/tests/integration_connect_mode.rs
+++ b/tests/integration_connect_mode.rs
@@ -177,6 +177,11 @@ impl TestCtx {
 
     /// Run `nb` with arbitrary args, automatically appending `--server` and `--token`.
     fn run(&self, args: &[&str]) -> CommandResult {
+        self.run_from_dir(args, &self.info.server_root)
+    }
+
+    /// Run `nb` from a specific working directory.
+    fn run_from_dir(&self, args: &[&str], cwd: &std::path::Path) -> CommandResult {
         let output = Command::new(&self.info.binary_path)
             .args(args)
             .args([
@@ -185,7 +190,7 @@ impl TestCtx {
                 "--token",
                 &self.info.token,
             ])
-            .current_dir(&self.info.server_root)
+            .current_dir(cwd)
             .env("PATH", &self.info.venv_path_env)
             .env("VIRTUAL_ENV", &self.info.venv_root)
             .env_remove("PYTHONHOME")
@@ -268,11 +273,10 @@ fn test_execute_without_restart_preserves_state() {
         return;
     };
 
-    let nb_path = ctx.copy_fixture("for_connect_restart.ipynb", "test_preserve.ipynb");
-    let nb_str = nb_path.to_str().unwrap();
+    ctx.copy_fixture("for_connect_restart.ipynb", "test_preserve.ipynb");
 
     // First: execute the full notebook to establish kernel state.
-    let result = ctx.run(&["execute", nb_str]).assert_success();
+    let result = ctx.run(&["execute", "test_preserve.ipynb"]).assert_success();
 
     assert!(
         result.stdout.contains("persistent_var = 999"),
@@ -283,7 +287,7 @@ fn test_execute_without_restart_preserves_state() {
     // Second: execute only cell-use (index 1) — no restart.
     // The kernel should still have `persistent_var` in scope.
     let result = ctx
-        .run(&["execute", nb_str, "--cell-index", "1"])
+        .run(&["execute", "test_preserve.ipynb", "--cell-index", "1"])
         .assert_success();
 
     assert!(
@@ -307,11 +311,10 @@ fn test_restart_kernel_clears_state() {
     };
 
     // Use a unique notebook name so this test has its own independent session.
-    let nb_path = ctx.copy_fixture("for_connect_restart.ipynb", "test_restart.ipynb");
-    let nb_str = nb_path.to_str().unwrap();
+    ctx.copy_fixture("for_connect_restart.ipynb", "test_restart.ipynb");
 
     // Step 1: run the full notebook to create the session and set state.
-    let result = ctx.run(&["execute", nb_str]).assert_success();
+    let result = ctx.run(&["execute", "test_restart.ipynb"]).assert_success();
 
     assert!(
         result.stdout.contains("persistent_var = 999"),
@@ -321,7 +324,7 @@ fn test_restart_kernel_clears_state() {
 
     // Step 2: run cell-use without restart — variable should still be in scope.
     let result = ctx
-        .run(&["execute", nb_str, "--cell-index", "1"])
+        .run(&["execute", "test_restart.ipynb", "--cell-index", "1"])
         .assert_success();
 
     assert!(
@@ -335,7 +338,7 @@ fn test_restart_kernel_clears_state() {
     let result = ctx
         .run(&[
             "execute",
-            nb_str,
+            "test_restart.ipynb",
             "--cell-index",
             "1",
             "--restart-kernel",
@@ -364,21 +367,47 @@ fn test_restart_kernel_then_full_notebook_works() {
     };
 
     // Use a unique notebook name so this test has its own independent session.
-    let nb_path = ctx.copy_fixture("for_connect_restart.ipynb", "test_restart_full.ipynb");
-    let nb_str = nb_path.to_str().unwrap();
+    ctx.copy_fixture("for_connect_restart.ipynb", "test_restart_full.ipynb");
 
     // Step 1: initial full execution to create the session.
-    ctx.run(&["execute", nb_str]).assert_success();
+    ctx.run(&["execute", "test_restart_full.ipynb"]).assert_success();
 
     // Step 2: full re-execution with --restart-kernel.
     // All cells are run in order from scratch, so cell-set runs before cell-use.
     let result = ctx
-        .run(&["execute", nb_str, "--restart-kernel"])
+        .run(&["execute", "test_restart_full.ipynb", "--restart-kernel"])
         .assert_success();
 
     assert!(
         result.stdout.contains("persistent_var = 999"),
         "Full notebook execution after restart should print 'persistent_var = 999'\nStdout: {}",
+        result.stdout
+    );
+}
+
+/// Execute a notebook from a CWD that differs from the server root.
+///
+/// This is the most common agent workflow: the agent runs from a project
+/// directory while the Jupyter server is rooted elsewhere. The notebook
+/// is read from the server via the Contents API.
+#[test]
+fn test_execute_from_different_cwd() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping connect-mode test: jupyter server not available");
+        return;
+    };
+
+    ctx.copy_fixture("for_connect_restart.ipynb", "test_cwd.ipynb");
+
+    // Run from a temporary directory that is NOT the server root.
+    let other_dir = TempDir::new().expect("Failed to create temp dir");
+    let result = ctx
+        .run_from_dir(&["execute", "test_cwd.ipynb"], other_dir.path())
+        .assert_success();
+
+    assert!(
+        result.stdout.contains("persistent_var = 999"),
+        "Execution from different CWD should read notebook from server and succeed\nStdout: {}",
         result.stdout
     );
 }

--- a/tests/integration_connect_mode.rs
+++ b/tests/integration_connect_mode.rs
@@ -276,7 +276,9 @@ fn test_execute_without_restart_preserves_state() {
     ctx.copy_fixture("for_connect_restart.ipynb", "test_preserve.ipynb");
 
     // First: execute the full notebook to establish kernel state.
-    let result = ctx.run(&["execute", "test_preserve.ipynb"]).assert_success();
+    let result = ctx
+        .run(&["execute", "test_preserve.ipynb"])
+        .assert_success();
 
     assert!(
         result.stdout.contains("persistent_var = 999"),
@@ -370,7 +372,8 @@ fn test_restart_kernel_then_full_notebook_works() {
     ctx.copy_fixture("for_connect_restart.ipynb", "test_restart_full.ipynb");
 
     // Step 1: initial full execution to create the session.
-    ctx.run(&["execute", "test_restart_full.ipynb"]).assert_success();
+    ctx.run(&["execute", "test_restart_full.ipynb"])
+        .assert_success();
 
     // Step 2: full re-execution with --restart-kernel.
     // All cells are run in order from scratch, so cell-set runs before cell-use.

--- a/tests/integration_connect_mode.rs
+++ b/tests/integration_connect_mode.rs
@@ -388,11 +388,7 @@ fn test_restart_kernel_then_full_notebook_works() {
     );
 }
 
-/// Execute a notebook from a CWD that differs from the server root.
-///
-/// This is the most common agent workflow: the agent runs from a project
-/// directory while the Jupyter server is rooted elsewhere. The notebook
-/// is read from the server via the Contents API.
+/// Execute from a CWD that differs from the server root.
 #[test]
 fn test_execute_from_different_cwd() {
     let Some(ctx) = TestCtx::new() else {


### PR DESCRIPTION
Fixes #81

In remote mode, read notebooks from the Jupyter Server via the Contents API (`GET /api/contents/{path}`) instead of the local filesystem.

## Changes

- `JupyterClient::get_notebook()` now reads notebook via Contents API with URL-encoded paths
- `read_notebook_remote()` helper in `common.rs` for all remote-mode commands
- `execute_notebook.rs` now reads from server or local filesystem depending on execution mode
- `add_cell`, `update_cell`, `delete_cell` read from server instead of local filesystem when connected
- New integration test `test_execute_from_different_cwd` now executes from a CWD that differs from server root

## Testing 

Start a Jupyter server in a directory, create a notebook there, then execute from a different directory in remote mode using:
```bash
cd /tmp/other-dir
nb execute test.ipynb --server http://localhost:9877 --token mytoken
```
Before this change: `Failed to read notebook: No such file or directory (os error 2)`
After this change: the notebook is read from the server and executes successfully.


| Command | Old same CWD | Old diff CWD | New same CWD | New diff CWD |
|---|---|---|---|---|
| `execute` | OK | **FAIL:** No such file | OK | **OK** |
| `read` | OK | **FAIL:** No such file | OK | **OK** |
| `search` | OK | **FAIL:** No such file | OK | **OK** |
| `create` | OK | OK | OK | OK |
| `cell add` | OK | **FAIL:** No such file | OK | **OK** |
| `cell update` | OK | **FAIL:** No such file | OK | **OK** |
| `cell delete` | OK | **FAIL:** No such file | OK | **OK** |
