### PR TITLE
Fix execute hang in remote mode

### DIFF
--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -259,28 +259,60 @@ impl ExecutionBackend for RemoteExecutor {
             } else {
                 tokio::select! {
                     kernel_msg = ws.recv_message() => {
-                        if let Some(msg) = kernel_msg? {
-                            let is_ours = msg.parent_header.as_ref()
-                                .map(|h| h.msg_id == msg_id).unwrap_or(false);
-                            if is_ours {
-                                match &msg.content {
-                                    JupyterMessageContent::ExecuteInput(input) => {
-                                        expected_ec = Some(input.execution_count.0 as i64);
-                                    }
-                                    JupyterMessageContent::Status(status) => {
-                                        if matches!(status.execution_state,
-                                            jupyter_protocol::ExecutionState::Idle) {
-                                            idle_received = true;
+                        match kernel_msg? {
+                            Some(msg) => {
+                                let is_ours = msg.parent_header.as_ref()
+                                    .map(|h| h.msg_id == msg_id).unwrap_or(false);
+                                if is_ours {
+                                    match &msg.content {
+                                        JupyterMessageContent::ExecuteInput(input) => {
+                                            expected_ec = Some(input.execution_count.0 as i64);
                                         }
+                                        JupyterMessageContent::Status(status) => {
+                                            if matches!(status.execution_state,
+                                                jupyter_protocol::ExecutionState::Idle) {
+                                                idle_received = true;
+                                            }
+                                        }
+                                        _ => {}
                                     }
-                                    _ => {}
                                 }
                             }
+                            None => break,
                         }
                     }
                     ydoc_result = ydoc.recv_update() => {
                         ydoc_result.context("Y.js update error")?;
                     }
+                    _ = tokio::time::sleep_until(deadline) => {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Fallback: loop exited via timeout or WS close.
+        // Collect any outputs we haven't seen yet.
+        if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
+            for (idx, url_path) in &cell_data.externalized_urls {
+                if fetched_urls.insert(url_path.clone()) {
+                    seen_indices.insert(*idx);
+                    if let Some(output) =
+                        Self::fetch_output(&http, &self.server_url, &self.token, url_path).await
+                    {
+                        if let Some(cb) = &on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+            }
+            for (idx, output) in &cell_data.inline_outputs {
+                if seen_indices.insert(*idx) {
+                    if let Some(cb) = &on_output {
+                        cb(output);
+                    }
+                    outputs.push(output.clone());
                 }
             }
         }
@@ -289,7 +321,25 @@ impl ExecutionBackend for RemoteExecutor {
             .read_cell_outputs(cell_idx)
             .ok()
             .and_then(|c| c.execution_count);
-        Ok(ExecutionResult::success(outputs, ec))
+        let has_error = outputs
+            .iter()
+            .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
+        if has_error {
+            let error_info = outputs.iter().find_map(|o| {
+                if let nbformat::v4::Output::Error(err) = o {
+                    Some(ExecutionError {
+                        ename: err.ename.clone(),
+                        evalue: err.evalue.clone(),
+                        traceback: err.traceback.clone(),
+                    })
+                } else {
+                    None
+                }
+            });
+            Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+        } else {
+            Ok(ExecutionResult::success(outputs, ec))
+        }
     }
 
     async fn stop(&mut self) -> Result<()> {

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -7,7 +7,7 @@ pub mod websocket;
 pub mod ydoc;
 pub mod ydoc_notebook_ops;
 
-use crate::execution::types::{ExecutionConfig, ExecutionError, ExecutionResult};
+use crate::execution::types::{ExecutionConfig, ExecutionResult};
 use crate::execution::ExecutionBackend;
 use anyhow::{Context, Result};
 use client::{JupyterClient, SessionInfo};
@@ -227,25 +227,7 @@ impl ExecutionBackend for RemoteExecutor {
                 }
 
                 if idle_received {
-                    let has_error = outputs
-                        .iter()
-                        .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
-                    let error_info = outputs.iter().find_map(|o| {
-                        if let nbformat::v4::Output::Error(err) = o {
-                            Some(ExecutionError {
-                                ename: err.ename.clone(),
-                                evalue: err.evalue.clone(),
-                                traceback: err.traceback.clone(),
-                            })
-                        } else {
-                            None
-                        }
-                    });
-                    return if has_error {
-                        Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
-                    } else {
-                        Ok(ExecutionResult::success(outputs, ec))
-                    };
+                    return Ok(ExecutionResult::from_outputs(outputs, ec));
                 }
             }
 
@@ -293,7 +275,7 @@ impl ExecutionBackend for RemoteExecutor {
 
         // Fallback: loop exited via timeout or WS close.
         // Collect any outputs we haven't seen yet.
-        if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
+        let ec = if let Ok(cell_data) = ydoc.read_cell_outputs(cell_idx) {
             for (idx, url_path) in &cell_data.externalized_urls {
                 if fetched_urls.insert(url_path.clone()) {
                     seen_indices.insert(*idx);
@@ -315,31 +297,12 @@ impl ExecutionBackend for RemoteExecutor {
                     outputs.push(output.clone());
                 }
             }
-        }
-
-        let ec = ydoc
-            .read_cell_outputs(cell_idx)
-            .ok()
-            .and_then(|c| c.execution_count);
-        let has_error = outputs
-            .iter()
-            .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
-        if has_error {
-            let error_info = outputs.iter().find_map(|o| {
-                if let nbformat::v4::Output::Error(err) = o {
-                    Some(ExecutionError {
-                        ename: err.ename.clone(),
-                        evalue: err.evalue.clone(),
-                        traceback: err.traceback.clone(),
-                    })
-                } else {
-                    None
-                }
-            });
-            Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+            cell_data.execution_count
         } else {
-            Ok(ExecutionResult::success(outputs, ec))
-        }
+            None
+        };
+
+        Ok(ExecutionResult::from_outputs(outputs, ec))
     }
 
     async fn stop(&mut self) -> Result<()> {

--- a/src/execution/types.rs
+++ b/src/execution/types.rs
@@ -105,6 +105,28 @@ impl ExecutionResult {
             error: Some(error),
         }
     }
+
+    /// Build a result by inspecting outputs for errors in a single pass.
+    pub fn from_outputs(
+        outputs: Vec<nbformat::v4::Output>,
+        execution_count: Option<i64>,
+    ) -> Self {
+        let error_info = outputs.iter().find_map(|o| {
+            if let nbformat::v4::Output::Error(err) = o {
+                Some(ExecutionError {
+                    ename: err.ename.clone(),
+                    evalue: err.evalue.clone(),
+                    traceback: err.traceback.clone(),
+                })
+            } else {
+                None
+            }
+        });
+        match error_info {
+            Some(err) => Self::error(outputs, execution_count, err),
+            None => Self::success(outputs, execution_count),
+        }
+    }
 }
 
 /// Output from a single execution message


### PR DESCRIPTION
Fixes #87

## Problem

`nb execute` in remote mode can hang indefinitely. The `tokio::select!` in the kernel message loop waits for WebSocket messages and Y.js updates but has no timeout arm. The per-cell deadline is only applied after `Status(Idle)` arrives. If that message is missed (race condition observed after `nb output clear` + `nb execute` in quick succession), the loop blocks forever.

A secondary issue: when the kernel WebSocket closes, `recv_message()` returns `Ok(None)`. The `if let Some(msg)` pattern silently skips `None`, re-enters the loop, and spins at 100% CPU since a closed socket returns `None` immediately on every read.

## Changes

Added timeout arm to `tokio::select!`. `sleep_until(deadline)` now serves as a select branch so the loop always exits within the configured per-cell timeout, regardless of whether `Status(Idle)` arrives. Matches the same pattern the local executor already uses (`timeout_at` wrapping each recv).

Fixed WebSocket close handling. Changed `if let Some(msg)` to `match` with an explicit `None => break` arm. On WS close the loop now exits into the fallback path instead of spinning.

Improved fallback path to collect outputs. Previously the fallback returned a blind `ExecutionResult::success`. Now it reads any remaining outputs from the Y.js document and uses `from_outputs` to detect errors, so a timed-out execution that produced an error still reports as failed.

Extracted `ExecutionResult::from_outputs` helper. Moved the error-detection scan (previously inlined in the happy path) into a reusable method on `ExecutionResult`. Single-pass `find_map` over outputs replaces the prior `any()` + `find_map()` double scan.