### PR TITLE
Add --gateway support for Jupyter Kernel Gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,9 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -2545,6 +2547,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ dirs = "5.0"
 dialoguer = "0.11"
 chrono = { version = "0.4", features = ["serde"] }
 
-# Remote mode dependencies
+# Remote mode dependencies (server + kernel-gateway WS)
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
-tokio-tungstenite = "0.21"
+tokio-tungstenite = { version = "0.21", features = ["native-tls-vendored"] }
 futures-util = "0.3"
 url = "2.5"
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,28 @@ nb execute experiment.ipynb --cell-index 0
 nb disconnect
 ```
 
+## Gateway Mode
+
+**Execute against a Jupyter Kernel Gateway when no full Jupyter Server is available.**
+
+A kernel gateway exposes kernels over REST and WebSocket but has no Contents API. The notebook stays local; only execution runs on the gateway.
+
+```bash
+nb execute notebook.ipynb \
+  --gateway http://kg.example.com:8888 \
+  --gateway-token "$KG_TOKEN"
+```
+
+If `--kernel-id` is omitted, `nb` reuses the first kernel on the gateway when listing is permitted, otherwise it starts a new one via `POST /api/kernels`.
+
+**Gateway options:**
+- `--gateway`: Kernel gateway URL (e.g. `http://host:8888`)
+- `--gateway-token`: Authentication token (required when `--gateway` is set)
+- `--gateway-auth-scheme`: Authorization scheme (default `token`; use `Bearer` for OAuth-style gateways)
+- `--kernel-id`: Target a specific kernel instead of discovering one
+
+**Note**: Gateway mode has no `nb connect` equivalent — pass the flags on each `nb execute` invocation.
+
 ## Commands
 
 | Command | Purpose |

--- a/skills/notebook-cli/SKILL.md
+++ b/skills/notebook-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notebook-cli
-description: Use the `nb` CLI for all Jupyter notebook (`.ipynb`) operations, including reading, inspecting, creating, editing cells, deleting cells, clearing outputs, searching, executing, and working with connected JupyterLab sessions. Required when an agent needs deterministic notebook manipulation without directly reading or writing raw notebook JSON.
+description: Use the `nb` CLI for all Jupyter notebook (`.ipynb`) operations, including reading, inspecting, creating, editing cells, deleting cells, clearing outputs, searching, executing, and working with connected JupyterLab sessions or remote kernel gateways. Required when an agent needs deterministic notebook manipulation without directly reading or writing raw notebook JSON.
 ---
 
 # Notebook CLI

--- a/skills/notebook-cli/references/execute.md
+++ b/skills/notebook-cli/references/execute.md
@@ -53,6 +53,18 @@ nb execute notebook.ipynb --cell "cell-id" --restart-kernel
 
 Prefer `nb connect` plus saved connection state for remote work. Do not put Jupyter authentication tokens in commands, prompts, logs, or examples; if a manual server connection is required, ask the user to establish it. `--restart-kernel` is remote-mode only.
 
+## Kernel Gateway
+
+```bash
+nb execute notebook.ipynb --gateway http://gateway:8888 --gateway-token "$KG_TOKEN"
+nb execute notebook.ipynb --gateway http://gateway:8888 --gateway-token "$KG_TOKEN" --kernel-id <id>
+nb execute notebook.ipynb --gateway http://gateway:8888 --gateway-token "$KG_TOKEN" --gateway-auth-scheme Bearer
+```
+
+Use `--gateway` for environments that expose only a Jupyter Kernel Gateway — kernels over REST and WebSocket, with no full notebook server. The notebook is read and written locally; only execution runs on the gateway. `--gateway-token` is required when `--gateway` is set. If no `--kernel-id` is given, `nb` reuses an existing kernel on the gateway when listing is permitted, otherwise it starts a new one. Default auth scheme is `token`; override with `--gateway-auth-scheme` only when the gateway requires another scheme.
+
+Do not put gateway tokens into commands, prompts, logs, or examples. Source them from environment variables or saved configuration; if the token is not available through those channels, ask the user to run the command themselves.
+
 ## Debugging Failed Cells
 
 1. Run `nb search notebook.ipynb --with-errors`.

--- a/src/commands/create_notebook.rs
+++ b/src/commands/create_notebook.rs
@@ -106,7 +106,8 @@ pub fn execute(args: CreateArgs) -> Result<()> {
                 .block_on(client.save_notebook(&server_path, &notebook))
                 .context("Failed to create notebook on server")?;
         }
-        crate::execution::types::ExecutionMode::Local => {
+        crate::execution::types::ExecutionMode::Local
+        | crate::execution::types::ExecutionMode::RemoteKernel { .. } => {
             notebook::write_notebook_atomic(&path, &notebook)
                 .context("Failed to write notebook")?;
         }

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -43,12 +43,28 @@ pub struct ExecuteNotebookArgs {
     pub end: Option<i32>,
 
     /// Remote server URL (enables remote mode)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "gateway")]
     pub server: Option<String>,
 
     /// Authentication token for remote server
     #[arg(long)]
     pub token: Option<String>,
+
+    /// Kernel gateway URL (enables remote-kernel mode, e.g. http://host:8888)
+    #[arg(long, conflicts_with = "server")]
+    pub gateway: Option<String>,
+
+    /// Authentication token for kernel gateway
+    #[arg(long, requires = "gateway")]
+    pub gateway_token: Option<String>,
+
+    /// Authorization scheme for the gateway token (e.g. "token", "Bearer")
+    #[arg(long, requires = "gateway", default_value = "token")]
+    pub gateway_auth_scheme: String,
+
+    /// Kernel ID on the gateway (auto-discovered if omitted)
+    #[arg(long, requires = "gateway")]
+    pub kernel_id: Option<String>,
 
     /// Output in JSON format instead of text
     #[arg(long)]
@@ -103,9 +119,23 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
 
     let file_path = common::normalize_notebook_path(&args.file);
 
-    // Determine execution mode before reading — remote mode reads from server
-    let mode =
-        crate::commands::common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
+    // Determine execution mode before reading — remote (server) mode reads
+    // from the server, remote-kernel mode reads locally but executes on a
+    // remote kernel gateway, and local mode does both locally.
+    let mode = if let Some(gateway_url) = args.gateway.clone() {
+        let token = args
+            .gateway_token
+            .clone()
+            .context("Must specify --gateway-token when using --gateway")?;
+        ExecutionMode::RemoteKernel {
+            gateway_url,
+            token,
+            kernel_id: args.kernel_id.clone(),
+            auth_scheme: args.gateway_auth_scheme.clone(),
+        }
+    } else {
+        common::resolve_execution_mode(args.server.clone(), args.token.clone())?
+    };
 
     // For remote mode, compute the server-relative path once and reuse it
     // for both the Contents API read and the session identifier.
@@ -129,7 +159,9 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
             )
             .await?
         }
-        ExecutionMode::Local => read_notebook(&file_path).context("Failed to read notebook")?,
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => {
+            read_notebook(&file_path).context("Failed to read notebook")?
+        }
     };
 
     // Determine cell range
@@ -163,6 +195,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         );
     }
 
+    // Get kernel from notebook metadata if not specified
     let notebook_kernel = notebook
         .metadata
         .kernelspec
@@ -170,10 +203,10 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         .map(|ks| ks.name.as_str());
 
     // For remote mode, reuse the pre-computed server-relative path.
-    // For local mode, use absolute path for working directory determination.
+    // For local and remote-kernel modes, use absolute path for working directory determination.
     let notebook_identifier = match &mode {
-        ExecutionMode::Remote { .. } => server_path.unwrap(),
-        ExecutionMode::Local => {
+        ExecutionMode::Remote { .. } => server_path.clone().expect("set for Remote mode"),
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => {
             let abs =
                 std::fs::canonicalize(&file_path).context("Failed to resolve notebook path")?;
             abs.to_str()
@@ -203,8 +236,10 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     let mut execution_results: HashMap<usize, crate::execution::types::ExecutionResult> =
         HashMap::new();
 
-    let is_streaming = matches!(mode, ExecutionMode::Remote { .. })
-        && matches!(format, OutputFormat::Text | OutputFormat::Markdown);
+    let is_streaming = matches!(
+        mode,
+        ExecutionMode::Remote { .. } | ExecutionMode::RemoteKernel { .. }
+    ) && matches!(format, OutputFormat::Text | OutputFormat::Markdown);
 
     // For streaming remote text mode, print notebook header before execution
     if is_streaming {
@@ -308,7 +343,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
 
     // Persist changes based on mode
     match mode {
-        ExecutionMode::Local => {
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => {
             // Write notebook to file
             write_notebook_atomic(&file_path, &notebook).context("Failed to write notebook")?;
         }

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -51,7 +51,7 @@ pub struct ExecuteNotebookArgs {
     pub token: Option<String>,
 
     /// Kernel gateway URL (enables remote-kernel mode, e.g. http://host:8888)
-    #[arg(long, conflicts_with = "server")]
+    #[arg(long, conflicts_with = "server", requires = "gateway_token")]
     pub gateway: Option<String>,
 
     /// Authentication token for kernel gateway
@@ -126,7 +126,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         let token = args
             .gateway_token
             .clone()
-            .context("Must specify --gateway-token when using --gateway")?;
+            .expect("--gateway-token is required when --gateway is set");
         ExecutionMode::RemoteKernel {
             gateway_url,
             token,

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -63,7 +63,10 @@ pub fn execute(args: ReadArgs) -> Result<()> {
                 &server_path,
             ))?
         }
-        crate::execution::types::ExecutionMode::Local => notebook::read_notebook(&file_path)?,
+        crate::execution::types::ExecutionMode::Local
+        | crate::execution::types::ExecutionMode::RemoteKernel { .. } => {
+            notebook::read_notebook(&file_path)?
+        }
     };
 
     // Determine format: markdown (default) or JSON

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -123,7 +123,8 @@ pub fn execute(args: SearchArgs) -> Result<()> {
                 &server_path,
             ))?
         }
-        crate::execution::types::ExecutionMode::Local => {
+        crate::execution::types::ExecutionMode::Local
+        | crate::execution::types::ExecutionMode::RemoteKernel { .. } => {
             // Phase 1: Text pre-filter - quick scan of raw file
             let file_content = fs::read_to_string(&file_path)?;
             if !re.is_match(&file_content) {
@@ -201,7 +202,10 @@ fn execute_with_errors(args: &SearchArgs) -> Result<()> {
                 &server_path,
             ))?
         }
-        crate::execution::types::ExecutionMode::Local => notebook::read_notebook(&file_path)?,
+        crate::execution::types::ExecutionMode::Local
+        | crate::execution::types::ExecutionMode::RemoteKernel { .. } => {
+            notebook::read_notebook(&file_path)?
+        }
     };
     let mut results = Vec::new();
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod local;
 pub mod remote;
+pub mod remote_kernel;
 pub mod types;
 
 use anyhow::Result;
@@ -47,6 +48,18 @@ pub fn create_backend(config: ExecutionConfig) -> Result<Box<dyn ExecutionBacken
         ExecutionMode::Local => Ok(Box::new(local::LocalExecutor::new(config)?)),
         ExecutionMode::Remote { server_url, token } => Ok(Box::new(remote::RemoteExecutor::new(
             config, server_url, token,
+        )?)),
+        ExecutionMode::RemoteKernel {
+            gateway_url,
+            token,
+            kernel_id,
+            auth_scheme,
+        } => Ok(Box::new(remote_kernel::RemoteKernelExecutor::new(
+            config,
+            gateway_url,
+            token,
+            kernel_id,
+            auth_scheme,
         )?)),
     }
 }

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -32,6 +32,38 @@ impl KernelWebSocket {
         Ok(Self { write, read })
     }
 
+    /// Connect to a kernel via WebSocket with an `Authorization` header.
+    ///
+    /// Used by the kernel-gateway path, which authenticates the WS upgrade
+    /// with e.g. `Authorization: token <gateway-token>`. `auth_value` is the
+    /// full header value (e.g. `"token notebooks"`).
+    pub async fn connect_with_auth(ws_url: &str, auth_value: &str) -> Result<Self> {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+        let mut req = ws_url
+            .into_client_request()
+            .context("Failed to build kernel WebSocket request")?;
+        req.headers_mut().insert(
+            "Authorization",
+            auth_value
+                .parse()
+                .context("Invalid Authorization header value")?,
+        );
+        req.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            "v1.kernel.websocket.jupyter.org"
+                .parse()
+                .context("Invalid Sec-WebSocket-Protocol value")?,
+        );
+
+        let (ws_stream, _) = connect_async(req)
+            .await
+            .context("Failed to connect to kernel WebSocket")?;
+
+        let (write, read) = ws_stream.split();
+        Ok(Self { write, read })
+    }
+
     /// Parse Jupyter's binary message format
     fn parse_binary_message(data: &[u8]) -> Option<JupyterMessage> {
         // Read number of buffers (first 8 bytes, little-endian)

--- a/src/execution/remote_kernel/executor.rs
+++ b/src/execution/remote_kernel/executor.rs
@@ -1,0 +1,312 @@
+//! Remote kernel (Jupyter Kernel Gateway) execution backend.
+
+use crate::execution::remote::websocket::KernelWebSocket;
+use crate::execution::types::{ExecutionConfig, ExecutionError, ExecutionResult};
+use crate::execution::{ExecutionBackend, OutputCallback};
+use anyhow::{Context, Result};
+use jupyter_protocol::messaging::JupyterMessageContent;
+use serde::Deserialize;
+
+/// Minimal subset of the Jupyter Kernel Gateway's `/api/kernels` response.
+/// We only need the kernel id; the gateway returns more fields but we ignore them.
+#[derive(Deserialize)]
+struct GatewayKernel {
+    id: String,
+}
+
+pub struct RemoteKernelExecutor {
+    config: ExecutionConfig,
+    gateway_url: String,
+    token: String,
+    kernel_id: Option<String>,
+    auth_scheme: String,
+    ws: Option<KernelWebSocket>,
+    http_client: reqwest::Client,
+}
+
+impl RemoteKernelExecutor {
+    pub fn new(
+        config: ExecutionConfig,
+        gateway_url: String,
+        token: String,
+        kernel_id: Option<String>,
+        auth_scheme: String,
+    ) -> Result<Self> {
+        Ok(Self {
+            config,
+            gateway_url,
+            token,
+            kernel_id,
+            auth_scheme,
+            ws: None,
+            http_client: reqwest::Client::new(),
+        })
+    }
+
+    fn auth_header(&self) -> String {
+        format!("{} {}", self.auth_scheme, self.token)
+    }
+
+    async fn discover_kernel_id(&self) -> Result<String> {
+        let url = format!("{}/api/kernels", self.gateway_url.trim_end_matches('/'));
+        let poll_interval = std::time::Duration::from_millis(500);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(180);
+
+        loop {
+            let response = self
+                .http_client
+                .get(&url)
+                .header("Authorization", self.auth_header())
+                .send()
+                .await
+                .context("Failed to connect to kernel gateway")?;
+
+            if !response.status().is_success() {
+                anyhow::bail!(
+                    "Gateway returned status {} for GET /api/kernels",
+                    response.status()
+                );
+            }
+
+            let kernels: Vec<GatewayKernel> = response
+                .json()
+                .await
+                .context("Failed to parse kernel list from gateway")?;
+
+            if let Some(kernel) = kernels.into_iter().next() {
+                return Ok(kernel.id);
+            }
+
+            if tokio::time::Instant::now() > deadline {
+                anyhow::bail!("No kernels found on gateway after polling for 180s");
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    fn ws_url_for_kernel(&self, kernel_id: &str) -> String {
+        // /api/kernels/<id>/channels — replace http(s) → ws(s) once.
+        format!(
+            "{}/api/kernels/{}/channels",
+            self.gateway_url
+                .trim_end_matches('/')
+                .replacen("http", "ws", 1),
+            kernel_id,
+        )
+    }
+
+    async fn execute_cell(
+        &mut self,
+        code: &str,
+        on_output: Option<&OutputCallback>,
+    ) -> Result<ExecutionResult> {
+        let ws = self.ws.as_mut().context("WebSocket not initialized")?;
+
+        let stop_on_error = !self.config.allow_errors;
+        let msg_id = ws
+            .send_execute_request(code, stop_on_error, None)
+            .await
+            .context("Failed to send execute request")?;
+
+        let mut outputs = Vec::new();
+        let mut execution_count: Option<i64> = None;
+        let mut error_info: Option<ExecutionError> = None;
+        let mut saw_busy = false;
+
+        let timeout = self.config.timeout;
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                anyhow::bail!("Execution timeout after {:?}", timeout);
+            }
+
+            let recv_result = tokio::time::timeout_at(deadline, ws.recv_message()).await;
+            let message = match recv_result {
+                Ok(Ok(Some(msg))) => msg,
+                Ok(Ok(None)) => anyhow::bail!("WebSocket connection closed unexpectedly"),
+                Ok(Err(e)) => return Err(e).context("Error reading WebSocket message"),
+                Err(_) => anyhow::bail!("Timeout reading WebSocket message"),
+            };
+
+            let is_our_message = message
+                .parent_header
+                .as_ref()
+                .map(|h| h.msg_id == msg_id)
+                .unwrap_or(false);
+
+            if !is_our_message {
+                continue;
+            }
+
+            match &message.content {
+                JupyterMessageContent::Status(status) => match status.execution_state {
+                    jupyter_protocol::ExecutionState::Busy => {
+                        saw_busy = true;
+                    }
+                    jupyter_protocol::ExecutionState::Idle if saw_busy => {
+                        break;
+                    }
+                    _ => {}
+                },
+                JupyterMessageContent::StreamContent(stream) => {
+                    let name = match stream.name {
+                        jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
+                        jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
+                    };
+                    let output = nbformat::v4::Output::Stream {
+                        name,
+                        text: nbformat::v4::MultilineString(stream.text.clone()),
+                    };
+                    if let Some(cb) = on_output {
+                        cb(&output);
+                    }
+                    outputs.push(output);
+                }
+                JupyterMessageContent::ExecuteResult(result) => {
+                    execution_count = Some(result.execution_count.value() as i64);
+                    let json = serde_json::json!({
+                        "output_type": "execute_result",
+                        "execution_count": result.execution_count.value(),
+                        "data": result.data,
+                        "metadata": result.metadata
+                    });
+                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                        if let Some(cb) = on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+                JupyterMessageContent::DisplayData(display) => {
+                    let json = serde_json::json!({
+                        "output_type": "display_data",
+                        "data": display.data,
+                        "metadata": display.metadata
+                    });
+                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                        if let Some(cb) = on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+                JupyterMessageContent::ErrorOutput(error) => {
+                    error_info = Some(ExecutionError {
+                        ename: error.ename.clone(),
+                        evalue: error.evalue.clone(),
+                        traceback: error.traceback.clone(),
+                    });
+                    let output = nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
+                        ename: error.ename.clone(),
+                        evalue: error.evalue.clone(),
+                        traceback: error.traceback.clone(),
+                    });
+                    if let Some(cb) = on_output {
+                        cb(&output);
+                    }
+                    outputs.push(output);
+                }
+                JupyterMessageContent::ExecuteReply(reply) if execution_count.is_none() => {
+                    execution_count = Some(reply.execution_count.value() as i64);
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(error) = error_info {
+            Ok(ExecutionResult::error(outputs, execution_count, error))
+        } else {
+            Ok(ExecutionResult::success(outputs, execution_count))
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionBackend for RemoteKernelExecutor {
+    async fn start(&mut self) -> Result<()> {
+        let kernel_id = match self.kernel_id.take() {
+            Some(id) => id,
+            None => self
+                .discover_kernel_id()
+                .await
+                .context("Failed to discover kernel from gateway")?,
+        };
+
+        let ws_url = self.ws_url_for_kernel(&kernel_id);
+        let auth_value = self.auth_header();
+        let ws = KernelWebSocket::connect_with_auth(&ws_url, &auth_value)
+            .await
+            .with_context(|| format!("Failed to connect to kernel {}", kernel_id))?;
+
+        self.ws = Some(ws);
+        self.kernel_id = Some(kernel_id);
+
+        Ok(())
+    }
+
+    async fn execute_code(
+        &mut self,
+        code: &str,
+        _cell_id: Option<&str>,
+        _cell_index: Option<usize>,
+        on_output: Option<&OutputCallback>,
+    ) -> Result<ExecutionResult> {
+        self.execute_cell(code, on_output).await
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        if let Some(ws) = self.ws.take() {
+            let _ = ws.close().await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn executor(gateway_url: &str, token: &str, auth_scheme: &str) -> RemoteKernelExecutor {
+        RemoteKernelExecutor::new(
+            ExecutionConfig::default(),
+            gateway_url.to_string(),
+            token.to_string(),
+            None,
+            auth_scheme.to_string(),
+        )
+        .expect("constructor should not fail")
+    }
+
+    #[test]
+    fn auth_header_uses_configured_scheme() {
+        let exec = executor("https://gw.example.com", "abc", "token");
+        assert_eq!(exec.auth_header(), "token abc");
+
+        let exec = executor("https://gw.example.com", "xyz", "Bearer");
+        assert_eq!(exec.auth_header(), "Bearer xyz");
+    }
+
+    #[test]
+    fn ws_url_swaps_scheme_and_appends_channels_path() {
+        let exec = executor("http://host:8888", "t", "token");
+        assert_eq!(
+            exec.ws_url_for_kernel("abc"),
+            "ws://host:8888/api/kernels/abc/channels"
+        );
+
+        let exec = executor("https://gw.example.com", "t", "token");
+        assert_eq!(
+            exec.ws_url_for_kernel("abc"),
+            "wss://gw.example.com/api/kernels/abc/channels"
+        );
+
+        // Trailing slash on the gateway URL must not produce a double slash.
+        let exec = executor("https://gw.example.com/", "t", "token");
+        assert_eq!(
+            exec.ws_url_for_kernel("abc"),
+            "wss://gw.example.com/api/kernels/abc/channels"
+        );
+    }
+}

--- a/src/execution/remote_kernel/executor.rs
+++ b/src/execution/remote_kernel/executor.rs
@@ -49,51 +49,101 @@ impl RemoteKernelExecutor {
 
     async fn discover_kernel_id(&self) -> Result<String> {
         let url = format!("{}/api/kernels", self.gateway_url.trim_end_matches('/'));
-        let poll_interval = std::time::Duration::from_millis(500);
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(180);
+        let response = self
+            .http_client
+            .get(&url)
+            .header("Authorization", self.auth_header())
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to kernel gateway at {}. Check that the URL is reachable.",
+                    self.gateway_url
+                )
+            })?;
 
-        loop {
-            let response = self
-                .http_client
-                .get(&url)
-                .header("Authorization", self.auth_header())
-                .send()
-                .await
-                .context("Failed to connect to kernel gateway")?;
-
-            if !response.status().is_success() {
-                anyhow::bail!(
-                    "Gateway returned status {} for GET /api/kernels",
-                    response.status()
-                );
+        let status = response.status();
+        if !status.is_success() {
+            match status.as_u16() {
+                401 | 403 => anyhow::bail!(
+                    "Gateway rejected authentication ({}). Check --gateway-token and --gateway-auth-scheme.",
+                    status
+                ),
+                404 => anyhow::bail!(
+                    "Gateway endpoint /api/kernels not found ({}). Check that --gateway points to a Jupyter Kernel Gateway.",
+                    status
+                ),
+                _ => anyhow::bail!("Gateway returned status {} for GET /api/kernels", status),
             }
-
-            let kernels: Vec<GatewayKernel> = response
-                .json()
-                .await
-                .context("Failed to parse kernel list from gateway")?;
-
-            if let Some(kernel) = kernels.into_iter().next() {
-                return Ok(kernel.id);
-            }
-
-            if tokio::time::Instant::now() > deadline {
-                anyhow::bail!("No kernels found on gateway after polling for 180s");
-            }
-
-            tokio::time::sleep(poll_interval).await;
         }
+
+        let kernels: Vec<GatewayKernel> = response
+            .json()
+            .await
+            .context("Failed to parse kernel list from gateway")?;
+
+        if let Some(kernel) = kernels.into_iter().next() {
+            return Ok(kernel.id);
+        }
+
+        eprintln!("No kernels running on gateway; starting a new one...");
+        self.start_kernel().await
+    }
+
+    async fn start_kernel(&self) -> Result<String> {
+        let url = format!("{}/api/kernels", self.gateway_url.trim_end_matches('/'));
+        let mut body = serde_json::Map::new();
+        if let Some(name) = self.config.kernel_name.as_ref() {
+            body.insert("name".to_string(), serde_json::Value::String(name.clone()));
+        }
+
+        let response = self
+            .http_client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .json(&serde_json::Value::Object(body))
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to start a kernel on gateway at {}",
+                    self.gateway_url
+                )
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            match status.as_u16() {
+                401 | 403 => anyhow::bail!(
+                    "Gateway rejected authentication ({}) when starting a kernel.",
+                    status
+                ),
+                _ => anyhow::bail!(
+                    "Gateway returned status {} when starting a kernel. Pass --kernel-id to use an existing kernel. Body: {}",
+                    status,
+                    body
+                ),
+            }
+        }
+
+        let kernel: GatewayKernel = response
+            .json()
+            .await
+            .context("Failed to parse kernel response from gateway")?;
+        Ok(kernel.id)
     }
 
     fn ws_url_for_kernel(&self, kernel_id: &str) -> String {
-        // /api/kernels/<id>/channels — replace http(s) → ws(s) once.
-        format!(
-            "{}/api/kernels/{}/channels",
-            self.gateway_url
-                .trim_end_matches('/')
-                .replacen("http", "ws", 1),
-            kernel_id,
-        )
+        let trimmed = self.gateway_url.trim_end_matches('/');
+        let base = if let Some(rest) = trimmed.strip_prefix("https://") {
+            format!("wss://{}", rest)
+        } else if let Some(rest) = trimmed.strip_prefix("http://") {
+            format!("ws://{}", rest)
+        } else {
+            trimmed.to_string()
+        };
+        format!("{}/api/kernels/{}/channels", base, kernel_id)
     }
 
     async fn execute_cell(
@@ -307,6 +357,13 @@ mod tests {
         assert_eq!(
             exec.ws_url_for_kernel("abc"),
             "wss://gw.example.com/api/kernels/abc/channels"
+        );
+
+        // "http" inside a path segment must not be rewritten — only the scheme is.
+        let exec = executor("https://gw.example.com/httpapi", "t", "token");
+        assert_eq!(
+            exec.ws_url_for_kernel("abc"),
+            "wss://gw.example.com/httpapi/api/kernels/abc/channels"
         );
     }
 }

--- a/src/execution/remote_kernel/mod.rs
+++ b/src/execution/remote_kernel/mod.rs
@@ -1,0 +1,3 @@
+mod executor;
+
+pub use executor::RemoteKernelExecutor;

--- a/src/execution/types.rs
+++ b/src/execution/types.rs
@@ -4,13 +4,21 @@ use std::time::Duration;
 
 use crate::commands::env_manager::EnvConfig;
 
-/// Execution mode: local (direct kernel) or remote (Jupyter server)
+/// Execution mode: local (direct kernel), remote (Jupyter server), or remote-kernel (gateway)
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExecutionMode {
     /// Local execution via direct kernel connection
     Local,
     /// Remote execution via Jupyter Server API
     Remote { server_url: String, token: String },
+    /// Remote kernel execution via Jupyter Kernel Gateway
+    RemoteKernel {
+        gateway_url: String,
+        token: String,
+        kernel_id: Option<String>,
+        /// Authorization scheme used with `token`, e.g. "token" or "Bearer".
+        auth_scheme: String,
+    },
 }
 
 /// Configuration for code execution


### PR DESCRIPTION
Adds a RemoteKernel execution mode that connects directly to a Jupyter Kernel Gateway via its REST + WebSocket APIs, for environments where there is a kernel gateway but no notebook server.

    nb execute notebook.ipynb \
        --gateway https://my-gateway.example.com \
        --gateway-token <token> \
        [--kernel-id <id>]