### PR TITLE
Fix connect mode with Jupyter Server vanilla (no collaboration packages)

### DIFF
--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -225,7 +225,7 @@ pub fn execute(args: AddCellArgs) -> Result<()> {
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
     match &mode {
-        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => execute_file_based(args),
         ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -221,22 +221,23 @@ fn parse_source_into_cells(text: &str, default_type: &CellType) -> Vec<ParsedCel
 }
 
 pub fn execute(args: AddCellArgs) -> Result<()> {
-    // Check if we should use real-time Y.js updates by resolving execution mode
     use crate::execution::types::ExecutionMode;
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
-    let use_realtime = matches!(mode, ExecutionMode::Remote { .. });
 
-    if use_realtime {
-        // Create Tokio runtime for async operations
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-
-        return runtime.block_on(execute_with_realtime(args, mode));
+    match &mode {
+        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Remote { .. } => {
+            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            if ydoc_available == Some(false) {
+                runtime.block_on(execute_with_contents_api(args, mode))
+            } else {
+                runtime.block_on(execute_with_realtime(args, mode))
+            }
+        }
     }
-
-    // Fallback to file-based updates
-    execute_file_based(args)
 }
 
 async fn execute_with_realtime(
@@ -356,6 +357,111 @@ async fn execute_with_realtime(
         notebook.cells.len() + num_added,
         &format,
     )?;
+
+    Ok(())
+}
+
+async fn execute_with_contents_api(
+    args: AddCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
+        _ => bail!("Expected remote execution mode"),
+    };
+
+    let file_path = common::normalize_notebook_path(&args.file);
+    let server_root = common::resolve_server_root();
+    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+
+    let client = crate::execution::remote::client::JupyterClient::new(
+        server_url.clone(),
+        token.clone(),
+    )?;
+    let mut notebook = client
+        .get_notebook(&notebook_server_path)
+        .await
+        .context("Failed to read notebook from server")?;
+
+    let raw_text = common::parse_source_text(&args.source)?;
+    let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
+
+    if parsed_cells.len() > 1 && args.id.is_some() {
+        bail!("--id cannot be used when adding multiple cells");
+    }
+
+    let insert_index = if let Some(idx) = args.insert_at {
+        if idx < 0 {
+            let abs_idx = idx.unsigned_abs() as usize;
+            if abs_idx > notebook.cells.len() {
+                bail!(
+                    "Negative index {} out of range (notebook has {} cells)",
+                    idx,
+                    notebook.cells.len()
+                );
+            }
+            notebook.cells.len() - abs_idx
+        } else {
+            let pos_idx = idx as usize;
+            if pos_idx > notebook.cells.len() {
+                bail!(
+                    "Index {} out of range (notebook has {} cells)",
+                    idx,
+                    notebook.cells.len()
+                );
+            }
+            pos_idx
+        }
+    } else if let Some(ref after_id) = args.after {
+        let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
+        index + 1
+    } else if let Some(ref before_id) = args.before {
+        let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
+        index
+    } else {
+        notebook.cells.len()
+    };
+
+    let mut added_cells: Vec<AddedCellInfo> = Vec::new();
+
+    for (i, parsed) in parsed_cells.into_iter().enumerate() {
+        let cell_id = if let Some(ref id) = args.id {
+            if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
+                bail!("Cell ID '{}' already exists in notebook", id);
+            }
+            CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+        } else {
+            CellId::from(Uuid::new_v4())
+        };
+
+        let cell_type_str = cell_type_to_str(&parsed.cell_type);
+        let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
+        let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
+
+        let actual_index = insert_index + i;
+        notebook.cells.insert(actual_index, new_cell);
+
+        added_cells.push(AddedCellInfo {
+            cell_type: cell_type_str.to_string(),
+            cell_id: cell_id.to_string(),
+            index: actual_index,
+        });
+    }
+
+    client
+        .save_notebook(&notebook_server_path, &notebook)
+        .await
+        .context("Failed to save notebook to server")?;
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+
+    output_results(&file_path, added_cells, notebook.cells.len(), &format)?;
 
     Ok(())
 }

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct AddCellArgs {
     /// Path to notebook file
     pub file: String,
@@ -226,25 +226,33 @@ pub fn execute(args: AddCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote {
-            ref server_url,
-            ref token,
-        } => {
+        ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
-                server_url,
-                token,
-                &args.server,
-                &args.token,
-            ));
-            if ydoc {
-                runtime.block_on(execute_with_realtime(args, mode))
-            } else {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            }
+            runtime.block_on(execute_remote(args, mode))
         }
+    }
+}
+
+/// Remote dispatch: cached Some(false) goes straight to the Contents API;
+/// otherwise try the Y.js realtime path and fall back on the definitive
+/// backend-absent signal. Transient errors propagate so a flaky
+/// collaboration server is never silently downgraded.
+async fn execute_remote(
+    args: AddCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let cached = common::resolve_ydoc_available(&args.server, &args.token);
+    if cached == Some(false) {
+        return execute_with_contents_api(args, mode).await;
+    }
+    match execute_with_realtime(args.clone(), mode.clone()).await {
+        Err(e) if crate::execution::remote::ydoc::is_yjs_unavailable(&e) => {
+            common::warn_stale_collab_cache(cached);
+            execute_with_contents_api(args, mode).await
+        }
+        result => result,
     }
 }
 

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -373,105 +373,84 @@ async fn execute_with_contents_api(
     args: AddCellArgs,
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
-    let (server_url, token) = match &mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
-            (server_url.clone(), token.clone())
+    let file = args.file.clone();
+    common::with_contents_api(&file, &mode, |notebook, file_path| {
+        let raw_text = common::parse_source_text(&args.source)?;
+        let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
+
+        if parsed_cells.len() > 1 && args.id.is_some() {
+            bail!("--id cannot be used when adding multiple cells");
         }
-        _ => bail!("Expected remote execution mode"),
-    };
 
-    let file_path = common::normalize_notebook_path(&args.file);
-    let server_root = common::resolve_server_root();
-    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
-
-    let client = crate::execution::remote::client::JupyterClient::new(
-        server_url.clone(),
-        token.clone(),
-    )?;
-    let mut notebook = client
-        .get_notebook(&notebook_server_path)
-        .await
-        .context("Failed to read notebook from server")?;
-
-    let raw_text = common::parse_source_text(&args.source)?;
-    let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
-
-    if parsed_cells.len() > 1 && args.id.is_some() {
-        bail!("--id cannot be used when adding multiple cells");
-    }
-
-    let insert_index = if let Some(idx) = args.insert_at {
-        if idx < 0 {
-            let abs_idx = idx.unsigned_abs() as usize;
-            if abs_idx > notebook.cells.len() {
-                bail!(
-                    "Negative index {} out of range (notebook has {} cells)",
-                    idx,
-                    notebook.cells.len()
-                );
+        let insert_index = if let Some(idx) = args.insert_at {
+            if idx < 0 {
+                let abs_idx = idx.unsigned_abs() as usize;
+                if abs_idx > notebook.cells.len() {
+                    bail!(
+                        "Negative index {} out of range (notebook has {} cells)",
+                        idx,
+                        notebook.cells.len()
+                    );
+                }
+                notebook.cells.len() - abs_idx
+            } else {
+                let pos_idx = idx as usize;
+                if pos_idx > notebook.cells.len() {
+                    bail!(
+                        "Index {} out of range (notebook has {} cells)",
+                        idx,
+                        notebook.cells.len()
+                    );
+                }
+                pos_idx
             }
-            notebook.cells.len() - abs_idx
+        } else if let Some(ref after_id) = args.after {
+            let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
+            index + 1
+        } else if let Some(ref before_id) = args.before {
+            let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
+            index
         } else {
-            let pos_idx = idx as usize;
-            if pos_idx > notebook.cells.len() {
-                bail!(
-                    "Index {} out of range (notebook has {} cells)",
-                    idx,
-                    notebook.cells.len()
-                );
-            }
-            pos_idx
-        }
-    } else if let Some(ref after_id) = args.after {
-        let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
-        index + 1
-    } else if let Some(ref before_id) = args.before {
-        let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
-        index
-    } else {
-        notebook.cells.len()
-    };
-
-    let mut added_cells: Vec<AddedCellInfo> = Vec::new();
-
-    for (i, parsed) in parsed_cells.into_iter().enumerate() {
-        let cell_id = if let Some(ref id) = args.id {
-            if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
-                bail!("Cell ID '{}' already exists in notebook", id);
-            }
-            CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
-        } else {
-            CellId::from(Uuid::new_v4())
+            notebook.cells.len()
         };
 
-        let cell_type_str = cell_type_to_str(&parsed.cell_type);
-        let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
-        let new_cell = create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
+        let mut added_cells: Vec<AddedCellInfo> = Vec::new();
 
-        let actual_index = insert_index + i;
-        notebook.cells.insert(actual_index, new_cell);
+        for (i, parsed) in parsed_cells.into_iter().enumerate() {
+            let cell_id = if let Some(ref id) = args.id {
+                if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
+                    bail!("Cell ID '{}' already exists in notebook", id);
+                }
+                CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+            } else {
+                CellId::from(Uuid::new_v4())
+            };
 
-        added_cells.push(AddedCellInfo {
-            cell_type: cell_type_str.to_string(),
-            cell_id: cell_id.to_string(),
-            index: actual_index,
-        });
-    }
+            let cell_type_str = cell_type_to_str(&parsed.cell_type);
+            let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
+            let new_cell =
+                create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
 
-    client
-        .save_notebook(&notebook_server_path, &notebook)
-        .await
-        .context("Failed to save notebook to server")?;
+            let actual_index = insert_index + i;
+            notebook.cells.insert(actual_index, new_cell);
 
-    let format = if args.json {
-        OutputFormat::Json
-    } else {
-        OutputFormat::Text
-    };
+            added_cells.push(AddedCellInfo {
+                cell_type: cell_type_str.to_string(),
+                cell_id: cell_id.to_string(),
+                index: actual_index,
+            });
+        }
 
-    output_results(&file_path, added_cells, notebook.cells.len(), &format)?;
+        let format = if args.json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
+        };
+        output_results(file_path, added_cells, notebook.cells.len(), &format)?;
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 fn execute_file_based(args: AddCellArgs) -> Result<()> {

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -226,15 +226,23 @@ pub fn execute(args: AddCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote { .. } => {
-            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+        ExecutionMode::Remote {
+            ref server_url,
+            ref token,
+        } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            if ydoc_available == Some(false) {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            } else {
+            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
+                server_url,
+                token,
+                &args.server,
+                &args.token,
+            ));
+            if ydoc {
                 runtime.block_on(execute_with_realtime(args, mode))
+            } else {
+                runtime.block_on(execute_with_contents_api(args, mode))
             }
         }
     }

--- a/src/commands/add_cell.rs
+++ b/src/commands/add_cell.rs
@@ -374,83 +374,84 @@ async fn execute_with_contents_api(
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
     let file = args.file.clone();
-    common::with_contents_api(&file, &mode, |notebook, file_path| {
-        let raw_text = common::parse_source_text(&args.source)?;
-        let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
+    let (file_path, added_cells, total_cells) =
+        common::with_contents_api(&file, &mode, |notebook, file_path| {
+            let raw_text = common::parse_source_text(&args.source)?;
+            let parsed_cells = parse_source_into_cells(&raw_text, &args.cell_type);
 
-        if parsed_cells.len() > 1 && args.id.is_some() {
-            bail!("--id cannot be used when adding multiple cells");
-        }
-
-        let insert_index = if let Some(idx) = args.insert_at {
-            if idx < 0 {
-                let abs_idx = idx.unsigned_abs() as usize;
-                if abs_idx > notebook.cells.len() {
-                    bail!(
-                        "Negative index {} out of range (notebook has {} cells)",
-                        idx,
-                        notebook.cells.len()
-                    );
-                }
-                notebook.cells.len() - abs_idx
-            } else {
-                let pos_idx = idx as usize;
-                if pos_idx > notebook.cells.len() {
-                    bail!(
-                        "Index {} out of range (notebook has {} cells)",
-                        idx,
-                        notebook.cells.len()
-                    );
-                }
-                pos_idx
+            if parsed_cells.len() > 1 && args.id.is_some() {
+                bail!("--id cannot be used when adding multiple cells");
             }
-        } else if let Some(ref after_id) = args.after {
-            let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
-            index + 1
-        } else if let Some(ref before_id) = args.before {
-            let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
-            index
-        } else {
-            notebook.cells.len()
-        };
 
-        let mut added_cells: Vec<AddedCellInfo> = Vec::new();
-
-        for (i, parsed) in parsed_cells.into_iter().enumerate() {
-            let cell_id = if let Some(ref id) = args.id {
-                if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
-                    bail!("Cell ID '{}' already exists in notebook", id);
+            let insert_index = if let Some(idx) = args.insert_at {
+                if idx < 0 {
+                    let abs_idx = idx.unsigned_abs() as usize;
+                    if abs_idx > notebook.cells.len() {
+                        bail!(
+                            "Negative index {} out of range (notebook has {} cells)",
+                            idx,
+                            notebook.cells.len()
+                        );
+                    }
+                    notebook.cells.len() - abs_idx
+                } else {
+                    let pos_idx = idx as usize;
+                    if pos_idx > notebook.cells.len() {
+                        bail!(
+                            "Index {} out of range (notebook has {} cells)",
+                            idx,
+                            notebook.cells.len()
+                        );
+                    }
+                    pos_idx
                 }
-                CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+            } else if let Some(ref after_id) = args.after {
+                let (index, _) = common::find_cell_by_id(&notebook.cells, after_id)?;
+                index + 1
+            } else if let Some(ref before_id) = args.before {
+                let (index, _) = common::find_cell_by_id(&notebook.cells, before_id)?;
+                index
             } else {
-                CellId::from(Uuid::new_v4())
+                notebook.cells.len()
             };
 
-            let cell_type_str = cell_type_to_str(&parsed.cell_type);
-            let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
-            let new_cell =
-                create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
+            let mut added_cells: Vec<AddedCellInfo> = Vec::new();
 
-            let actual_index = insert_index + i;
-            notebook.cells.insert(actual_index, new_cell);
+            for (i, parsed) in parsed_cells.into_iter().enumerate() {
+                let cell_id = if let Some(ref id) = args.id {
+                    if notebook.cells.iter().any(|c| c.id().as_str() == *id) {
+                        bail!("Cell ID '{}' already exists in notebook", id);
+                    }
+                    CellId::new(id).map_err(|e| anyhow::anyhow!("Invalid cell ID: {}", e))?
+                } else {
+                    CellId::from(Uuid::new_v4())
+                };
 
-            added_cells.push(AddedCellInfo {
-                cell_type: cell_type_str.to_string(),
-                cell_id: cell_id.to_string(),
-                index: actual_index,
-            });
-        }
+                let cell_type_str = cell_type_to_str(&parsed.cell_type);
+                let metadata = parsed.metadata.unwrap_or_else(create_empty_metadata);
+                let new_cell =
+                    create_cell(parsed.cell_type, cell_id.clone(), metadata, parsed.source);
 
-        let format = if args.json {
-            OutputFormat::Json
-        } else {
-            OutputFormat::Text
-        };
-        output_results(file_path, added_cells, notebook.cells.len(), &format)?;
+                let actual_index = insert_index + i;
+                notebook.cells.insert(actual_index, new_cell);
 
-        Ok(())
-    })
-    .await
+                added_cells.push(AddedCellInfo {
+                    cell_type: cell_type_str.to_string(),
+                    cell_id: cell_id.to_string(),
+                    index: actual_index,
+                });
+            }
+
+            Ok((file_path.to_string(), added_cells, notebook.cells.len()))
+        })
+        .await?;
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_results(&file_path, added_cells, total_cells, &format)
 }
 
 fn execute_file_based(args: AddCellArgs) -> Result<()> {

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use nbformat::v4::Cell;
 use serde::Serialize;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct ClearOutputsArgs {
     /// Path to notebook file
     pub file: String,
@@ -59,25 +59,33 @@ pub fn execute(args: ClearOutputsArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote {
-            ref server_url,
-            ref token,
-        } => {
+        ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
-                server_url,
-                token,
-                &args.server,
-                &args.token,
-            ));
-            if ydoc {
-                runtime.block_on(execute_with_realtime(args, mode))
-            } else {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            }
+            runtime.block_on(execute_remote(args, mode))
         }
+    }
+}
+
+/// Remote dispatch: cached Some(false) goes straight to the Contents API;
+/// otherwise try the Y.js realtime path and fall back on the definitive
+/// backend-absent signal. Transient errors propagate so a flaky
+/// collaboration server is never silently downgraded.
+async fn execute_remote(
+    args: ClearOutputsArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let cached = common::resolve_ydoc_available(&args.server, &args.token);
+    if cached == Some(false) {
+        return execute_with_contents_api(args, mode).await;
+    }
+    match execute_with_realtime(args.clone(), mode.clone()).await {
+        Err(e) if crate::execution::remote::ydoc::is_yjs_unavailable(&e) => {
+            common::warn_stale_collab_cache(cached);
+            execute_with_contents_api(args, mode).await
+        }
+        result => result,
     }
 }
 

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -57,14 +57,20 @@ pub fn execute(args: ClearOutputsArgs) -> Result<()> {
     use crate::execution::types::ExecutionMode;
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
-    if matches!(mode, ExecutionMode::Remote { .. }) {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        return runtime.block_on(execute_with_realtime(args, mode));
+    match &mode {
+        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Remote { .. } => {
+            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            if ydoc_available == Some(false) {
+                runtime.block_on(execute_with_contents_api(args, mode))
+            } else {
+                runtime.block_on(execute_with_realtime(args, mode))
+            }
+        }
     }
-
-    execute_file_based(args)
 }
 
 async fn execute_with_realtime(
@@ -101,6 +107,70 @@ async fn execute_with_realtime(
         file: file_path,
         cells_cleared,
         execution_counts_cleared: true,
+    };
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)?;
+
+    Ok(())
+}
+
+async fn execute_with_contents_api(
+    args: ClearOutputsArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
+        _ => bail!("Expected remote execution mode"),
+    };
+
+    let file_path = common::normalize_notebook_path(&args.file);
+    let server_root = common::resolve_server_root();
+    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+
+    let client = crate::execution::remote::client::JupyterClient::new(
+        server_url.clone(),
+        token.clone(),
+    )?;
+    let mut notebook = client
+        .get_notebook(&notebook_server_path)
+        .await
+        .context("Failed to read notebook from server")?;
+
+    let cells_cleared = if let Some(ref cell_id) = args.cell {
+        let (_, cell) = common::find_cell_by_id_mut(&mut notebook.cells, cell_id)?;
+        clear_cell_output(cell, args.keep_execution_count)?;
+        1
+    } else if let Some(cell_index) = args.cell_index {
+        let index = common::normalize_index(cell_index, notebook.cells.len())?;
+        clear_cell_output(&mut notebook.cells[index], args.keep_execution_count)?;
+        1
+    } else {
+        let mut count = 0;
+        for cell in &mut notebook.cells {
+            if let Cell::Code { .. } = cell {
+                clear_cell_output(cell, args.keep_execution_count)?;
+                count += 1;
+            }
+        }
+        count
+    };
+
+    client
+        .save_notebook(&notebook_server_path, &notebook)
+        .await
+        .context("Failed to save notebook to server")?;
+
+    let result = ClearOutputsResult {
+        file: file_path,
+        cells_cleared,
+        execution_counts_cleared: !args.keep_execution_count,
     };
 
     let format = if args.json {

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -58,7 +58,7 @@ pub fn execute(args: ClearOutputsArgs) -> Result<()> {
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
     match &mode {
-        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => execute_file_based(args),
         ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -131,64 +131,43 @@ async fn execute_with_contents_api(
     args: ClearOutputsArgs,
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
-    let (server_url, token) = match &mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
-            (server_url.clone(), token.clone())
-        }
-        _ => bail!("Expected remote execution mode"),
-    };
-
-    let file_path = common::normalize_notebook_path(&args.file);
-    let server_root = common::resolve_server_root();
-    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
-
-    let client = crate::execution::remote::client::JupyterClient::new(
-        server_url.clone(),
-        token.clone(),
-    )?;
-    let mut notebook = client
-        .get_notebook(&notebook_server_path)
-        .await
-        .context("Failed to read notebook from server")?;
-
-    let cells_cleared = if let Some(ref cell_id) = args.cell {
-        let (_, cell) = common::find_cell_by_id_mut(&mut notebook.cells, cell_id)?;
-        clear_cell_output(cell, args.keep_execution_count)?;
-        1
-    } else if let Some(cell_index) = args.cell_index {
-        let index = common::normalize_index(cell_index, notebook.cells.len())?;
-        clear_cell_output(&mut notebook.cells[index], args.keep_execution_count)?;
-        1
-    } else {
-        let mut count = 0;
-        for cell in &mut notebook.cells {
-            if let Cell::Code { .. } = cell {
-                clear_cell_output(cell, args.keep_execution_count)?;
-                count += 1;
+    let file = args.file.clone();
+    common::with_contents_api(&file, &mode, |notebook, file_path| {
+        let cells_cleared = if let Some(ref cell_id) = args.cell {
+            let (_, cell) = common::find_cell_by_id_mut(&mut notebook.cells, cell_id)?;
+            clear_cell_output(cell, args.keep_execution_count)?;
+            1
+        } else if let Some(cell_index) = args.cell_index {
+            let index = common::normalize_index(cell_index, notebook.cells.len())?;
+            clear_cell_output(&mut notebook.cells[index], args.keep_execution_count)?;
+            1
+        } else {
+            let mut count = 0;
+            for cell in &mut notebook.cells {
+                if let Cell::Code { .. } = cell {
+                    clear_cell_output(cell, args.keep_execution_count)?;
+                    count += 1;
+                }
             }
-        }
-        count
-    };
+            count
+        };
 
-    client
-        .save_notebook(&notebook_server_path, &notebook)
-        .await
-        .context("Failed to save notebook to server")?;
+        let result = ClearOutputsResult {
+            file: file_path.to_string(),
+            cells_cleared,
+            execution_counts_cleared: !args.keep_execution_count,
+        };
 
-    let result = ClearOutputsResult {
-        file: file_path,
-        cells_cleared,
-        execution_counts_cleared: !args.keep_execution_count,
-    };
+        let format = if args.json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
+        };
+        output_result(&result, &format)?;
 
-    let format = if args.json {
-        OutputFormat::Json
-    } else {
-        OutputFormat::Text
-    };
-    output_result(&result, &format)?;
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 fn execute_file_based(args: ClearOutputsArgs) -> Result<()> {

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -132,7 +132,7 @@ async fn execute_with_contents_api(
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
     let file = args.file.clone();
-    common::with_contents_api(&file, &mode, |notebook, file_path| {
+    let result = common::with_contents_api(&file, &mode, |notebook, file_path| {
         let cells_cleared = if let Some(ref cell_id) = args.cell {
             let (_, cell) = common::find_cell_by_id_mut(&mut notebook.cells, cell_id)?;
             clear_cell_output(cell, args.keep_execution_count)?;
@@ -152,22 +152,20 @@ async fn execute_with_contents_api(
             count
         };
 
-        let result = ClearOutputsResult {
+        Ok(ClearOutputsResult {
             file: file_path.to_string(),
             cells_cleared,
             execution_counts_cleared: !args.keep_execution_count,
-        };
-
-        let format = if args.json {
-            OutputFormat::Json
-        } else {
-            OutputFormat::Text
-        };
-        output_result(&result, &format)?;
-
-        Ok(())
+        })
     })
-    .await
+    .await?;
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)
 }
 
 fn execute_file_based(args: ClearOutputsArgs) -> Result<()> {

--- a/src/commands/clear_outputs.rs
+++ b/src/commands/clear_outputs.rs
@@ -59,15 +59,23 @@ pub fn execute(args: ClearOutputsArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote { .. } => {
-            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+        ExecutionMode::Remote {
+            ref server_url,
+            ref token,
+        } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            if ydoc_available == Some(false) {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            } else {
+            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
+                server_url,
+                token,
+                &args.server,
+                &args.token,
+            ));
+            if ydoc {
                 runtime.block_on(execute_with_realtime(args, mode))
+            } else {
+                runtime.block_on(execute_with_contents_api(args, mode))
             }
         }
     }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -258,6 +258,22 @@ pub fn resolve_execution_mode(
     }
 }
 
+/// Resolve ydoc_available from saved connection config.
+/// Returns None for ad-hoc --server/--token (caller should try Y.js and fall back).
+/// Returns Some(bool) from saved connection's probe result.
+pub fn resolve_ydoc_available(
+    server_arg: &Option<String>,
+    token_arg: &Option<String>,
+) -> Option<bool> {
+    if server_arg.is_some() && token_arg.is_some() {
+        return None;
+    }
+    Config::load()
+        .ok()
+        .and_then(|c| c.connection)
+        .and_then(|c| c.ydoc_available)
+}
+
 /// Get the Jupyter server root directory from saved connection config.
 /// Returns None for manual connections or when no config exists.
 pub fn resolve_server_root() -> Option<String> {

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -435,9 +435,10 @@ mod tests {
 
     /// Minimal Contents API stub: serves GET with a valid one-cell notebook and
     /// answers PUT with the given status, recording every PUT body.
-    /// Note: with_contents_api also calls Config::load() from the process cwd;
-    /// the crate root has no .jupyter/cli.json, so server root resolves to None
-    /// and the request path is the file name as given.
+    /// Note: with_contents_api also calls Config::load() from the process cwd,
+    /// which may pick up a developer-local ./.jupyter/cli.json and change the
+    /// request path; the tests are insulated because this stub ignores the
+    /// request path entirely.
     async fn contents_api_stub(put_status: u16) -> ContentsStub {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -289,8 +289,8 @@ pub async fn resolve_ydoc_with_probe(
                 token.to_string(),
             );
             match client {
-                Ok(c) => c.probe_ydoc().await.unwrap_or(true),
-                Err(_) => true,
+                Ok(c) => c.probe_ydoc().await.unwrap_or(false),
+                Err(_) => false,
             }
         }
     }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -260,8 +260,9 @@ pub fn resolve_execution_mode(
 
 /// Resolve cached ydoc_available from saved connection config.
 /// Returns None for ad-hoc --server/--token connections and for saved
-/// connections without a cached probe result; `resolve_ydoc_with_probe`
-/// then probes the server live.
+/// connections without a cached probe result. None is a routing hint meaning
+/// "unknown": the executor tries Y.js and falls back to the Contents API path
+/// on the definitive backend-absent signal.
 pub fn resolve_ydoc_available(
     server_arg: &Option<String>,
     token_arg: &Option<String>,
@@ -275,25 +276,14 @@ pub fn resolve_ydoc_available(
         .and_then(|c| c.ydoc_available)
 }
 
-pub async fn resolve_ydoc_with_probe(
-    server_url: &str,
-    token: &str,
-    server_arg: &Option<String>,
-    token_arg: &Option<String>,
-) -> bool {
-    let cached = resolve_ydoc_available(server_arg, token_arg);
-    match cached {
-        Some(v) => v,
-        None => {
-            let client = crate::execution::remote::client::JupyterClient::new(
-                server_url.to_string(),
-                token.to_string(),
-            );
-            match client {
-                Ok(c) => c.probe_ydoc().await.unwrap_or(false),
-                Err(_) => false,
-            }
-        }
+/// Print the self-heal hint when a cached "collaborative" connection turns
+/// out to have no Y.js backend anymore.
+pub fn warn_stale_collab_cache(cached: Option<bool>) {
+    if cached == Some(true) {
+        eprintln!(
+            "Collaboration backend no longer found on server; using Contents API. \
+             Run 'nb connect' to refresh."
+        );
     }
 }
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -258,9 +258,10 @@ pub fn resolve_execution_mode(
     }
 }
 
-/// Resolve ydoc_available from saved connection config.
-/// Returns None for ad-hoc --server/--token (caller should try Y.js and fall back).
-/// Returns Some(bool) from saved connection's probe result.
+/// Resolve cached ydoc_available from saved connection config.
+/// Returns None for ad-hoc --server/--token connections and for saved
+/// connections without a cached probe result; `resolve_ydoc_with_probe`
+/// then probes the server live.
 pub fn resolve_ydoc_available(
     server_arg: &Option<String>,
     token_arg: &Option<String>,
@@ -298,14 +299,12 @@ pub async fn resolve_ydoc_with_probe(
 
 /// Read-modify-save a notebook via the Contents API.
 /// Handles: extract credentials, normalize path, fetch notebook, call `mutate`, save back.
-/// The closure receives (&mut Notebook, &normalized_file_path).
-pub async fn with_contents_api<F>(
-    file: &str,
-    mode: &ExecutionMode,
-    mutate: F,
-) -> Result<()>
+/// The closure receives (&mut Notebook, &normalized_file_path) and returns a
+/// value that is handed back to the caller only after the save succeeds, so
+/// callers report results only for persisted mutations.
+pub async fn with_contents_api<F, T>(file: &str, mode: &ExecutionMode, mutate: F) -> Result<T>
 where
-    F: FnOnce(&mut nbformat::v4::Notebook, &str) -> Result<()>,
+    F: FnOnce(&mut nbformat::v4::Notebook, &str) -> Result<T>,
 {
     let (server_url, token) = match mode {
         ExecutionMode::Remote { server_url, token } => (server_url.clone(), token.clone()),
@@ -316,21 +315,20 @@ where
     let server_root = resolve_server_root();
     let notebook_server_path = notebook_path_for_server(&file_path, server_root.as_deref());
 
-    let client =
-        crate::execution::remote::client::JupyterClient::new(server_url, token)?;
+    let client = crate::execution::remote::client::JupyterClient::new(server_url, token)?;
     let mut notebook = client
         .get_notebook(&notebook_server_path)
         .await
         .context("Failed to read notebook from server")?;
 
-    mutate(&mut notebook, &file_path)?;
+    let result = mutate(&mut notebook, &file_path)?;
 
     client
         .save_notebook(&notebook_server_path, &notebook)
         .await
         .context("Failed to save notebook to server")?;
 
-    Ok(())
+    Ok(result)
 }
 
 /// Get the Jupyter server root directory from saved connection config.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -427,12 +427,25 @@ mod tests {
         assert_eq!(super::unescape_string("\\n\\t\\r"), "\n\t\r");
     }
 
-    /// Minimal Contents API stub: serves GET with a valid empty notebook and
-    /// answers PUT with the given status. Returns the bound server URL.
-    async fn contents_api_stub(put_status: u16) -> String {
+    struct ContentsStub {
+        url: String,
+        put_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        put_bodies: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    /// Minimal Contents API stub: serves GET with a valid one-cell notebook and
+    /// answers PUT with the given status, recording every PUT body.
+    /// Note: with_contents_api also calls Config::load() from the process cwd;
+    /// the crate root has no .jupyter/cli.json, so server root resolves to None
+    /// and the request path is the file name as given.
+    async fn contents_api_stub(put_status: u16) -> ContentsStub {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let put_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let put_bodies = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let put_count_srv = std::sync::Arc::clone(&put_count);
+        let put_bodies_srv = std::sync::Arc::clone(&put_bodies);
         tokio::spawn(async move {
             loop {
                 let Ok((mut sock, _)) = listener.accept().await else {
@@ -471,14 +484,16 @@ mod tests {
                     buf.extend_from_slice(&tmp[..n]);
                 }
                 let response = if head.starts_with("GET") {
-                    let nb =
-                        r#"{"content":{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}}"#;
+                    let nb = r#"{"content":{"cells":[{"cell_type":"code","execution_count":null,"id":"c1","metadata":{},"outputs":[],"source":["original"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}}"#;
                     format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                         nb.len(),
                         nb
                     )
                 } else {
+                    put_count_srv.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let body = String::from_utf8_lossy(&buf[body_start..]).to_string();
+                    put_bodies_srv.lock().unwrap().push(body);
                     format!(
                         "HTTP/1.1 {} X\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}",
                         put_status
@@ -488,7 +503,11 @@ mod tests {
                 let _ = sock.shutdown().await;
             }
         });
-        format!("http://{}", addr)
+        ContentsStub {
+            url: format!("http://{}", addr),
+            put_count,
+            put_bodies,
+        }
     }
 
     fn remote_mode(server_url: String) -> ExecutionMode {
@@ -499,22 +518,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_contents_api_returns_mutation_result_after_successful_save() {
-        let url = contents_api_stub(200).await;
-        let result = super::with_contents_api("test.ipynb", &remote_mode(url), |notebook, _| {
-            assert!(notebook.cells.is_empty());
-            Ok(42)
-        })
-        .await;
+    async fn with_contents_api_saves_mutated_notebook_then_returns_result() {
+        let stub = contents_api_stub(200).await;
+        let result =
+            super::with_contents_api("test.ipynb", &remote_mode(stub.url), |notebook, _| {
+                match &mut notebook.cells[0] {
+                    nbformat::v4::Cell::Code { source, .. } => {
+                        *source = vec!["mutated".to_string()]
+                    }
+                    _ => panic!("expected code cell"),
+                }
+                Ok(42)
+            })
+            .await;
         assert_eq!(result.unwrap(), 42);
+        let bodies = stub.put_bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 1);
+        assert!(
+            bodies[0].contains("mutated") && !bodies[0].contains("original"),
+            "PUT body must contain the mutated notebook: {}",
+            bodies[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn with_contents_api_skips_save_when_mutation_fails() {
+        let stub = contents_api_stub(200).await;
+        let result = super::with_contents_api(
+            "test.ipynb",
+            &remote_mode(stub.url),
+            |_, _| -> anyhow::Result<i32> { anyhow::bail!("mutation rejected") },
+        )
+        .await;
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("mutation rejected"));
+        assert_eq!(
+            stub.put_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a failed mutation must not be saved"
+        );
     }
 
     #[tokio::test]
     async fn with_contents_api_withholds_result_when_save_fails() {
-        let url = contents_api_stub(500).await;
+        let stub = contents_api_stub(500).await;
         let mutated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let mutated_clone = std::sync::Arc::clone(&mutated);
-        let result = super::with_contents_api("test.ipynb", &remote_mode(url), move |_, _| {
+        let result = super::with_contents_api("test.ipynb", &remote_mode(stub.url), move |_, _| {
             mutated_clone.store(true, std::sync::atomic::Ordering::SeqCst);
             Ok(42)
         })

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -426,4 +426,107 @@ mod tests {
         assert_eq!(super::unescape_string("no escapes"), "no escapes");
         assert_eq!(super::unescape_string("\\n\\t\\r"), "\n\t\r");
     }
+
+    /// Minimal Contents API stub: serves GET with a valid empty notebook and
+    /// answers PUT with the given status. Returns the bound server URL.
+    async fn contents_api_stub(put_status: u16) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 1024];
+                // Read until end of headers, then drain any body by content-length
+                let body_start = loop {
+                    let n = sock.read(&mut tmp).await.unwrap_or(0);
+                    if n == 0 {
+                        break None;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                    if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                        break Some(pos + 4);
+                    }
+                };
+                let Some(body_start) = body_start else {
+                    continue;
+                };
+                let head = String::from_utf8_lossy(&buf[..body_start]).to_string();
+                let content_length: usize = head
+                    .lines()
+                    .find_map(|l| {
+                        l.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(|v| v.trim().parse().unwrap_or(0))
+                    })
+                    .unwrap_or(0);
+                while buf.len() - body_start < content_length {
+                    let n = sock.read(&mut tmp).await.unwrap_or(0);
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                }
+                let response = if head.starts_with("GET") {
+                    let nb =
+                        r#"{"content":{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}}"#;
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        nb.len(),
+                        nb
+                    )
+                } else {
+                    format!(
+                        "HTTP/1.1 {} X\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}",
+                        put_status
+                    )
+                };
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        format!("http://{}", addr)
+    }
+
+    fn remote_mode(server_url: String) -> ExecutionMode {
+        ExecutionMode::Remote {
+            server_url,
+            token: "t".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn with_contents_api_returns_mutation_result_after_successful_save() {
+        let url = contents_api_stub(200).await;
+        let result = super::with_contents_api("test.ipynb", &remote_mode(url), |notebook, _| {
+            assert!(notebook.cells.is_empty());
+            Ok(42)
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn with_contents_api_withholds_result_when_save_fails() {
+        let url = contents_api_stub(500).await;
+        let mutated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mutated_clone = std::sync::Arc::clone(&mutated);
+        let result = super::with_contents_api("test.ipynb", &remote_mode(url), move |_, _| {
+            mutated_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(42)
+        })
+        .await;
+        // The mutation ran, but a failed save must surface as an error so the
+        // caller never reports success for an unpersisted change.
+        assert!(mutated.load(std::sync::atomic::Ordering::SeqCst));
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to save notebook to server"),
+            "unexpected error: {}",
+            err
+        );
+    }
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -296,6 +296,43 @@ pub async fn resolve_ydoc_with_probe(
     }
 }
 
+/// Read-modify-save a notebook via the Contents API.
+/// Handles: extract credentials, normalize path, fetch notebook, call `mutate`, save back.
+/// The closure receives (&mut Notebook, &normalized_file_path).
+pub async fn with_contents_api<F>(
+    file: &str,
+    mode: &ExecutionMode,
+    mutate: F,
+) -> Result<()>
+where
+    F: FnOnce(&mut nbformat::v4::Notebook, &str) -> Result<()>,
+{
+    let (server_url, token) = match mode {
+        ExecutionMode::Remote { server_url, token } => (server_url.clone(), token.clone()),
+        _ => bail!("Expected remote execution mode"),
+    };
+
+    let file_path = normalize_notebook_path(file);
+    let server_root = resolve_server_root();
+    let notebook_server_path = notebook_path_for_server(&file_path, server_root.as_deref());
+
+    let client =
+        crate::execution::remote::client::JupyterClient::new(server_url, token)?;
+    let mut notebook = client
+        .get_notebook(&notebook_server_path)
+        .await
+        .context("Failed to read notebook from server")?;
+
+    mutate(&mut notebook, &file_path)?;
+
+    client
+        .save_notebook(&notebook_server_path, &notebook)
+        .await
+        .context("Failed to save notebook to server")?;
+
+    Ok(())
+}
+
 /// Get the Jupyter server root directory from saved connection config.
 /// Returns None for manual connections or when no config exists.
 pub fn resolve_server_root() -> Option<String> {

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -274,6 +274,28 @@ pub fn resolve_ydoc_available(
         .and_then(|c| c.ydoc_available)
 }
 
+pub async fn resolve_ydoc_with_probe(
+    server_url: &str,
+    token: &str,
+    server_arg: &Option<String>,
+    token_arg: &Option<String>,
+) -> bool {
+    let cached = resolve_ydoc_available(server_arg, token_arg);
+    match cached {
+        Some(v) => v,
+        None => {
+            let client = crate::execution::remote::client::JupyterClient::new(
+                server_url.to_string(),
+                token.to_string(),
+            );
+            match client {
+                Ok(c) => c.probe_ydoc().await.unwrap_or(true),
+                Err(_) => true,
+            }
+        }
+    }
+}
+
 /// Get the Jupyter server root directory from saved connection config.
 /// Returns None for manual connections or when no config exists.
 pub fn resolve_server_root() -> Option<String> {

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -118,7 +118,7 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
 
     // Probe Y.js/collaboration backend availability
     let ydoc_available = match JupyterClient::new(selected.url.clone(), selected.token.clone()) {
-        Ok(client) => Some(client.probe_ydoc().await.unwrap_or(true)),
+        Ok(client) => Some(client.probe_ydoc().await.unwrap_or(false)),
         Err(_) => None,
     };
 
@@ -150,10 +150,10 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
 
     println!("\n✓ Connected to Jupyter server at {}", selected.url);
     println!("  Working directory: {}", selected.working_dir);
-    if ydoc_available == Some(true) {
-        println!("  Mode: collaborative (Y.js available)");
-    } else {
-        println!("  Mode: direct (no collaboration backend)");
+    match ydoc_available {
+        Some(true) => println!("  Mode: collaborative (Y.js available)"),
+        Some(false) => println!("  Mode: direct (no collaboration backend)"),
+        None => {}
     }
 
     // Show environment info if using uv or pixi
@@ -195,8 +195,12 @@ async fn connect_manual(server_url: String, token: String, skip_validation: bool
         println!("✓ Connection validated");
     }
 
-    // Probe Y.js/collaboration backend
-    let ydoc_available = Some(client.probe_ydoc().await.unwrap_or(true));
+    // Probe Y.js/collaboration backend (skip if validation is skipped)
+    let ydoc_available = if skip_validation {
+        None
+    } else {
+        Some(client.probe_ydoc().await.unwrap_or(false))
+    };
 
     // Create connection
     let connection = JupyterConnection {
@@ -222,10 +226,10 @@ async fn connect_manual(server_url: String, token: String, skip_validation: bool
     let _config_path = config.save()?;
 
     println!("\n✓ Connected to Jupyter server at {}", server_url);
-    if ydoc_available == Some(true) {
-        println!("  Mode: collaborative (Y.js available)");
-    } else {
-        println!("  Mode: direct (no collaboration backend)");
+    match ydoc_available {
+        Some(true) => println!("  Mode: collaborative (Y.js available)"),
+        Some(false) => println!("  Mode: direct (no collaboration backend)"),
+        None => {}
     }
 
     Ok(())

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -116,10 +116,16 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
         select_server_interactive(&valid_servers)?
     };
 
-    // Probe Y.js/collaboration backend availability
-    let ydoc_available = match JupyterClient::new(selected.url.clone(), selected.token.clone()) {
-        Ok(client) => Some(client.probe_ydoc().await.unwrap_or(false)),
-        Err(_) => None,
+    // Probe Y.js/collaboration backend availability. A probe error maps to
+    // None (unknown), not Some(false): caching "direct" on a transient failure
+    // would silently route a real collaboration server to the kernel-WS path.
+    let ydoc_available = if args.skip_validation {
+        None
+    } else {
+        match JupyterClient::new(selected.url.clone(), selected.token.clone()) {
+            Ok(client) => client.probe_ydoc().await.ok(),
+            Err(_) => None,
+        }
     };
 
     // Create connection
@@ -195,11 +201,13 @@ async fn connect_manual(server_url: String, token: String, skip_validation: bool
         println!("✓ Connection validated");
     }
 
-    // Probe Y.js/collaboration backend (skip if validation is skipped)
+    // Probe Y.js/collaboration backend (skip if validation is skipped).
+    // A probe error maps to None (unknown) rather than Some(false) so a
+    // transient failure is not cached as a permanent "direct" routing.
     let ydoc_available = if skip_validation {
         None
     } else {
-        Some(client.probe_ydoc().await.unwrap_or(false))
+        client.probe_ydoc().await.ok()
     };
 
     // Create connection

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -116,6 +116,12 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
         select_server_interactive(&valid_servers)?
     };
 
+    // Probe Y.js/collaboration backend availability
+    let ydoc_available = match JupyterClient::new(selected.url.clone(), selected.token.clone()) {
+        Ok(client) => Some(client.probe_ydoc().await.unwrap_or(true)),
+        Err(_) => None,
+    };
+
     // Create connection
     let connection = JupyterConnection {
         server_url: selected.url.clone(),
@@ -132,6 +138,7 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
             .project_root
             .as_ref()
             .map(|p| p.display().to_string()),
+        ydoc_available,
     };
 
     // Save config
@@ -143,6 +150,11 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
 
     println!("\n✓ Connected to Jupyter server at {}", selected.url);
     println!("  Working directory: {}", selected.working_dir);
+    if ydoc_available == Some(true) {
+        println!("  Mode: collaborative (Y.js available)");
+    } else {
+        println!("  Mode: direct (no collaboration backend)");
+    }
 
     // Show environment info if using uv or pixi
     match env_config.manager {
@@ -171,16 +183,20 @@ async fn execute_async(args: ConnectArgs) -> Result<()> {
 }
 
 async fn connect_manual(server_url: String, token: String, skip_validation: bool) -> Result<()> {
+    let client = JupyterClient::new(server_url.clone(), token.clone())?;
+
     // Validate connection if requested
     if !skip_validation {
         println!("🔍 Validating connection...");
-        let client = JupyterClient::new(server_url.clone(), token.clone())?;
         client
             .test_connection()
             .await
             .context("Failed to connect to server")?;
         println!("✓ Connection validated");
     }
+
+    // Probe Y.js/collaboration backend
+    let ydoc_available = Some(client.probe_ydoc().await.unwrap_or(true));
 
     // Create connection
     let connection = JupyterConnection {
@@ -195,6 +211,7 @@ async fn connect_manual(server_url: String, token: String, skip_validation: bool
         },
         env_manager: None,
         project_root: None,
+        ydoc_available,
     };
 
     // Save config
@@ -205,6 +222,11 @@ async fn connect_manual(server_url: String, token: String, skip_validation: bool
     let _config_path = config.save()?;
 
     println!("\n✓ Connected to Jupyter server at {}", server_url);
+    if ydoc_available == Some(true) {
+        println!("  Mode: collaborative (Y.js available)");
+    } else {
+        println!("  Mode: direct (no collaboration backend)");
+    }
 
     Ok(())
 }

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use serde::Serialize;
 use std::collections::HashSet;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct DeleteCellArgs {
     /// Path to notebook file
     pub file: String,
@@ -48,25 +48,33 @@ pub fn execute(args: DeleteCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote {
-            ref server_url,
-            ref token,
-        } => {
+        ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
-                server_url,
-                token,
-                &args.server,
-                &args.token,
-            ));
-            if ydoc {
-                runtime.block_on(execute_with_realtime(args, mode))
-            } else {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            }
+            runtime.block_on(execute_remote(args, mode))
         }
+    }
+}
+
+/// Remote dispatch: cached Some(false) goes straight to the Contents API;
+/// otherwise try the Y.js realtime path and fall back on the definitive
+/// backend-absent signal. Transient errors propagate so a flaky
+/// collaboration server is never silently downgraded.
+async fn execute_remote(
+    args: DeleteCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let cached = common::resolve_ydoc_available(&args.server, &args.token);
+    if cached == Some(false) {
+        return execute_with_contents_api(args, mode).await;
+    }
+    match execute_with_realtime(args.clone(), mode.clone()).await {
+        Err(e) if crate::execution::remote::ydoc::is_yjs_unavailable(&e) => {
+            common::warn_stale_collab_cache(cached);
+            execute_with_contents_api(args, mode).await
+        }
+        result => result,
     }
 }
 

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -43,22 +43,23 @@ struct DeleteCellResult {
 }
 
 pub fn execute(args: DeleteCellArgs) -> Result<()> {
-    // Check if we should use real-time Y.js updates by resolving execution mode
     use crate::execution::types::ExecutionMode;
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
-    let use_realtime = matches!(mode, ExecutionMode::Remote { .. });
 
-    if use_realtime {
-        // Create Tokio runtime for async operations
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-
-        return runtime.block_on(execute_with_realtime(args, mode));
+    match &mode {
+        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Remote { .. } => {
+            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            if ydoc_available == Some(false) {
+                runtime.block_on(execute_with_contents_api(args, mode))
+            } else {
+                runtime.block_on(execute_with_realtime(args, mode))
+            }
+        }
     }
-
-    // Fallback to file-based updates
-    execute_file_based(args)
 }
 
 async fn execute_with_realtime(
@@ -136,6 +137,85 @@ async fn execute_with_realtime(
         file: file_path.clone(),
         cells_deleted,
         remaining_cells,
+    };
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)?;
+
+    Ok(())
+}
+
+async fn execute_with_contents_api(
+    args: DeleteCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
+        _ => bail!("Expected remote execution mode"),
+    };
+
+    let file_path = common::normalize_notebook_path(&args.file);
+    let server_root = common::resolve_server_root();
+    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+
+    let client = crate::execution::remote::client::JupyterClient::new(
+        server_url.clone(),
+        token.clone(),
+    )?;
+    let mut notebook = client
+        .get_notebook(&notebook_server_path)
+        .await
+        .context("Failed to read notebook from server")?;
+
+    let mut indices_to_delete: HashSet<usize> = HashSet::new();
+
+    if !args.cell.is_empty() {
+        for id in &args.cell {
+            let (index, _) = common::find_cell_by_id(&notebook.cells, id)?;
+            indices_to_delete.insert(index);
+        }
+    } else if !args.cell_index.is_empty() {
+        for idx in &args.cell_index {
+            let normalized = common::normalize_index(*idx, notebook.cells.len())?;
+            indices_to_delete.insert(normalized);
+        }
+    } else if let Some(ref range_str) = args.range {
+        let (start, end) = parse_range(range_str, notebook.cells.len())?;
+        for i in start..end {
+            indices_to_delete.insert(i);
+        }
+    } else {
+        bail!("Must specify --cell, --cell-index, or --range");
+    }
+
+    if indices_to_delete.len() >= notebook.cells.len() {
+        bail!("Cannot delete all cells from notebook (must keep at least 1 cell)");
+    }
+
+    let mut sorted_indices: Vec<usize> = indices_to_delete.into_iter().collect();
+    sorted_indices.sort_by(|a, b| b.cmp(a));
+
+    for idx in &sorted_indices {
+        notebook.cells.remove(*idx);
+    }
+
+    let cells_deleted = sorted_indices.len();
+
+    client
+        .save_notebook(&notebook_server_path, &notebook)
+        .await
+        .context("Failed to save notebook to server")?;
+
+    let result = DeleteCellResult {
+        file: file_path,
+        cells_deleted,
+        remaining_cells: notebook.cells.len(),
     };
 
     let format = if args.json {

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -47,7 +47,7 @@ pub fn execute(args: DeleteCellArgs) -> Result<()> {
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
     match &mode {
-        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => execute_file_based(args),
         ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -161,79 +161,58 @@ async fn execute_with_contents_api(
     args: DeleteCellArgs,
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
-    let (server_url, token) = match &mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
-            (server_url.clone(), token.clone())
+    let file = args.file.clone();
+    common::with_contents_api(&file, &mode, |notebook, file_path| {
+        let mut indices_to_delete: HashSet<usize> = HashSet::new();
+
+        if !args.cell.is_empty() {
+            for id in &args.cell {
+                let (index, _) = common::find_cell_by_id(&notebook.cells, id)?;
+                indices_to_delete.insert(index);
+            }
+        } else if !args.cell_index.is_empty() {
+            for idx in &args.cell_index {
+                let normalized = common::normalize_index(*idx, notebook.cells.len())?;
+                indices_to_delete.insert(normalized);
+            }
+        } else if let Some(ref range_str) = args.range {
+            let (start, end) = parse_range(range_str, notebook.cells.len())?;
+            for i in start..end {
+                indices_to_delete.insert(i);
+            }
+        } else {
+            bail!("Must specify --cell, --cell-index, or --range");
         }
-        _ => bail!("Expected remote execution mode"),
-    };
 
-    let file_path = common::normalize_notebook_path(&args.file);
-    let server_root = common::resolve_server_root();
-    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
-
-    let client = crate::execution::remote::client::JupyterClient::new(
-        server_url.clone(),
-        token.clone(),
-    )?;
-    let mut notebook = client
-        .get_notebook(&notebook_server_path)
-        .await
-        .context("Failed to read notebook from server")?;
-
-    let mut indices_to_delete: HashSet<usize> = HashSet::new();
-
-    if !args.cell.is_empty() {
-        for id in &args.cell {
-            let (index, _) = common::find_cell_by_id(&notebook.cells, id)?;
-            indices_to_delete.insert(index);
+        if indices_to_delete.len() >= notebook.cells.len() {
+            bail!("Cannot delete all cells from notebook (must keep at least 1 cell)");
         }
-    } else if !args.cell_index.is_empty() {
-        for idx in &args.cell_index {
-            let normalized = common::normalize_index(*idx, notebook.cells.len())?;
-            indices_to_delete.insert(normalized);
+
+        let mut sorted_indices: Vec<usize> = indices_to_delete.into_iter().collect();
+        sorted_indices.sort_by(|a, b| b.cmp(a));
+
+        for idx in &sorted_indices {
+            notebook.cells.remove(*idx);
         }
-    } else if let Some(ref range_str) = args.range {
-        let (start, end) = parse_range(range_str, notebook.cells.len())?;
-        for i in start..end {
-            indices_to_delete.insert(i);
-        }
-    } else {
-        bail!("Must specify --cell, --cell-index, or --range");
-    }
 
-    if indices_to_delete.len() >= notebook.cells.len() {
-        bail!("Cannot delete all cells from notebook (must keep at least 1 cell)");
-    }
+        let cells_deleted = sorted_indices.len();
 
-    let mut sorted_indices: Vec<usize> = indices_to_delete.into_iter().collect();
-    sorted_indices.sort_by(|a, b| b.cmp(a));
+        let result = DeleteCellResult {
+            file: file_path.to_string(),
+            cells_deleted,
+            remaining_cells: notebook.cells.len(),
+        };
 
-    for idx in &sorted_indices {
-        notebook.cells.remove(*idx);
-    }
+        let format = if args.json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
+        };
+        output_result(&result, &format)?;
 
-    let cells_deleted = sorted_indices.len();
-
-    client
-        .save_notebook(&notebook_server_path, &notebook)
-        .await
-        .context("Failed to save notebook to server")?;
-
-    let result = DeleteCellResult {
-        file: file_path,
-        cells_deleted,
-        remaining_cells: notebook.cells.len(),
-    };
-
-    let format = if args.json {
-        OutputFormat::Json
-    } else {
-        OutputFormat::Text
-    };
-    output_result(&result, &format)?;
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 fn execute_file_based(args: DeleteCellArgs) -> Result<()> {

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -162,7 +162,7 @@ async fn execute_with_contents_api(
     mode: crate::execution::types::ExecutionMode,
 ) -> Result<()> {
     let file = args.file.clone();
-    common::with_contents_api(&file, &mode, |notebook, file_path| {
+    let result = common::with_contents_api(&file, &mode, |notebook, file_path| {
         let mut indices_to_delete: HashSet<usize> = HashSet::new();
 
         if !args.cell.is_empty() {
@@ -197,22 +197,20 @@ async fn execute_with_contents_api(
 
         let cells_deleted = sorted_indices.len();
 
-        let result = DeleteCellResult {
+        Ok(DeleteCellResult {
             file: file_path.to_string(),
             cells_deleted,
             remaining_cells: notebook.cells.len(),
-        };
-
-        let format = if args.json {
-            OutputFormat::Json
-        } else {
-            OutputFormat::Text
-        };
-        output_result(&result, &format)?;
-
-        Ok(())
+        })
     })
-    .await
+    .await?;
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)
 }
 
 fn execute_file_based(args: DeleteCellArgs) -> Result<()> {

--- a/src/commands/delete_cell.rs
+++ b/src/commands/delete_cell.rs
@@ -48,15 +48,23 @@ pub fn execute(args: DeleteCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote { .. } => {
-            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+        ExecutionMode::Remote {
+            ref server_url,
+            ref token,
+        } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            if ydoc_available == Some(false) {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            } else {
+            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
+                server_url,
+                token,
+                &args.server,
+                &args.token,
+            ));
+            if ydoc {
                 runtime.block_on(execute_with_realtime(args, mode))
+            } else {
+                runtime.block_on(execute_with_contents_api(args, mode))
             }
         }
     }

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -221,7 +221,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // FileID call instead of a separate probe round trip.
     let ydoc_available = match &mode {
         ExecutionMode::Remote { .. } => common::resolve_ydoc_available(&args.server, &args.token),
-        ExecutionMode::Local => None,
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => None,
     };
 
     // Create execution config

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -220,9 +220,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     // --server/--token connections carry no cache and detect via the first
     // FileID call instead of a separate probe round trip.
     let ydoc_available = match &mode {
-        ExecutionMode::Remote { .. } => {
-            common::resolve_ydoc_available(&args.server, &args.token)
-        }
+        ExecutionMode::Remote { .. } => common::resolve_ydoc_available(&args.server, &args.token),
         ExecutionMode::Local => None,
     };
 

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -215,6 +215,9 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         }
     };
 
+    // Resolve ydoc availability for remote mode
+    let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+
     // Create execution config
     let config = ExecutionConfig {
         mode: mode.clone(),
@@ -224,6 +227,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         notebook_path: Some(notebook_identifier.clone()),
         env_config: env_config.clone(),
         restart_kernel: args.restart_kernel,
+        ydoc_available,
     };
 
     // Create and start backend (reuse kernel for all cells)
@@ -342,14 +346,27 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
     }
 
     // Persist changes based on mode
-    match mode {
+    match &mode {
         ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => {
             // Write notebook to file
             write_notebook_atomic(&file_path, &notebook).context("Failed to write notebook")?;
         }
-        ExecutionMode::Remote { .. } => {
-            // In remote mode, outputs are read from Y.js document during execution.
-            // The server auto-saves to disk via jupyter-server-documents.
+        ExecutionMode::Remote {
+            server_url, token, ..
+        } => {
+            if ydoc_available != Some(true) {
+                let client = crate::execution::remote::client::JupyterClient::new(
+                    server_url.clone(),
+                    token.clone(),
+                )?;
+                let server_root = common::resolve_server_root();
+                let save_path =
+                    common::notebook_path_for_server(&file_path, server_root.as_deref());
+                client
+                    .save_notebook(&save_path, &notebook)
+                    .await
+                    .context("Failed to save notebook to server")?;
+            }
         }
     }
 

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -215,13 +215,14 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         }
     };
 
-    // Resolve ydoc availability for remote mode (probe server if not cached)
+    // Cached Y.js availability is a routing hint: Some(false) skips Y.js,
+    // anything else tries Y.js and falls back inside the executor. Ad-hoc
+    // --server/--token connections carry no cache and detect via the first
+    // FileID call instead of a separate probe round trip.
     let ydoc_available = match &mode {
-        ExecutionMode::Remote {
-            server_url, token, ..
-        } => Some(
-            common::resolve_ydoc_with_probe(server_url, token, &args.server, &args.token).await,
-        ),
+        ExecutionMode::Remote { .. } => {
+            common::resolve_ydoc_available(&args.server, &args.token)
+        }
         ExecutionMode::Local => None,
     };
 
@@ -336,6 +337,9 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         }
     }
 
+    // Capture before stop(): teardown drops the Y.js connection
+    let server_persists_outputs = backend.server_persists_outputs();
+
     // Stop backend (just closes WebSocket, session persists)
     backend.stop().await?;
 
@@ -361,7 +365,7 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         ExecutionMode::Remote {
             server_url, token, ..
         } => {
-            if ydoc_available != Some(true) {
+            if !server_persists_outputs {
                 let client = crate::execution::remote::client::JupyterClient::new(
                     server_url.clone(),
                     token.clone(),

--- a/src/commands/execute_notebook.rs
+++ b/src/commands/execute_notebook.rs
@@ -215,8 +215,15 @@ async fn execute_async(args: ExecuteNotebookArgs) -> Result<()> {
         }
     };
 
-    // Resolve ydoc availability for remote mode
-    let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+    // Resolve ydoc availability for remote mode (probe server if not cached)
+    let ydoc_available = match &mode {
+        ExecutionMode::Remote {
+            server_url, token, ..
+        } => Some(
+            common::resolve_ydoc_with_probe(server_url, token, &args.server, &args.token).await,
+        ),
+        ExecutionMode::Local => None,
+    };
 
     // Create execution config
     let config = ExecutionConfig {

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -43,13 +43,21 @@ pub struct ReadArgs {
     /// Show only markdown cells
     #[arg(long = "only-markdown", alias = "markdown-cells", conflicts_with_all = ["cell", "cell_index", "only_code"])]
     pub only_markdown: bool,
+
+    /// Jupyter server URL (read from server instead of local filesystem)
+    #[arg(long)]
+    pub server: Option<String>,
+
+    /// Authentication token for Jupyter server
+    #[arg(long)]
+    pub token: Option<String>,
 }
 
 pub fn execute(args: ReadArgs) -> Result<()> {
     let file_path = common::normalize_notebook_path(&args.file);
 
-    // Read from server when connected, otherwise from local filesystem
-    let mode = common::resolve_execution_mode(None, None)?;
+    // Read from server when connected (or given --server/--token), else local
+    let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
     let notebook = match &mode {
         crate::execution::types::ExecutionMode::Remote { server_url, token } => {
             let server_root = common::resolve_server_root();

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use nbformat::v4::Cell;
 use serde::Serialize;
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct UpdateCellArgs {
     /// Path to notebook file
     pub file: String,
@@ -88,25 +88,33 @@ pub fn execute(args: UpdateCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote {
-            ref server_url,
-            ref token,
-        } => {
+        ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
-                server_url,
-                token,
-                &args.server,
-                &args.token,
-            ));
-            if ydoc {
-                runtime.block_on(execute_with_realtime(args, mode))
-            } else {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            }
+            runtime.block_on(execute_remote(args, mode))
         }
+    }
+}
+
+/// Remote dispatch: cached Some(false) goes straight to the Contents API;
+/// otherwise try the Y.js realtime path and fall back on the definitive
+/// backend-absent signal. Transient errors propagate so a flaky
+/// collaboration server is never silently downgraded.
+async fn execute_remote(
+    args: UpdateCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    let cached = common::resolve_ydoc_available(&args.server, &args.token);
+    if cached == Some(false) {
+        return execute_with_contents_api(args, mode).await;
+    }
+    match execute_with_realtime(args.clone(), mode.clone()).await {
+        Err(e) if crate::execution::remote::ydoc::is_yjs_unavailable(&e) => {
+            common::warn_stale_collab_cache(cached);
+            execute_with_contents_api(args, mode).await
+        }
+        result => result,
     }
 }
 

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -83,22 +83,23 @@ pub fn execute(args: UpdateCellArgs) -> Result<()> {
         bail!("Must specify --cell or --cell-index");
     }
 
-    // Check if we should use real-time Y.js updates by resolving execution mode
     use crate::execution::types::ExecutionMode;
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
-    let use_realtime = matches!(mode, ExecutionMode::Remote { .. });
 
-    if use_realtime {
-        // Create Tokio runtime for async operations
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-
-        return runtime.block_on(execute_with_realtime(args, mode));
+    match &mode {
+        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Remote { .. } => {
+            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            if ydoc_available == Some(false) {
+                runtime.block_on(execute_with_contents_api(args, mode))
+            } else {
+                runtime.block_on(execute_with_realtime(args, mode))
+            }
+        }
     }
-
-    // Fallback to file-based updates
-    execute_file_based(args)
 }
 
 async fn execute_with_realtime(
@@ -170,6 +171,166 @@ async fn execute_with_realtime(
     // Output result
     let result = UpdateCellResult {
         file: file_path.clone(),
+        cell_id,
+        index,
+        updated: updates,
+    };
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)?;
+
+    Ok(())
+}
+
+async fn execute_with_contents_api(
+    args: UpdateCellArgs,
+    mode: crate::execution::types::ExecutionMode,
+) -> Result<()> {
+    use nbformat::v4::Cell;
+
+    let (server_url, token) = match &mode {
+        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
+            (server_url.clone(), token.clone())
+        }
+        _ => bail!("Expected remote execution mode"),
+    };
+
+    let file_path = common::normalize_notebook_path(&args.file);
+    let server_root = common::resolve_server_root();
+    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
+
+    let client = crate::execution::remote::client::JupyterClient::new(
+        server_url.clone(),
+        token.clone(),
+    )?;
+    let mut notebook = client
+        .get_notebook(&notebook_server_path)
+        .await
+        .context("Failed to read notebook from server")?;
+
+    let (index, cell_id) = if let Some(ref id) = args.cell {
+        let (idx, cell) = common::find_cell_by_id(&notebook.cells, id)?;
+        (idx, cell.id().to_string())
+    } else if let Some(cell_index) = args.cell_index {
+        let idx = common::normalize_index(cell_index, notebook.cells.len())?;
+        let id = notebook.cells[idx].id().to_string();
+        (idx, id)
+    } else {
+        unreachable!("Already validated cell selector");
+    };
+
+    let mut updates = Vec::new();
+    let cell = &mut notebook.cells[index];
+
+    if let Some(ref source_text) = args.source {
+        let new_source = common::parse_source(source_text)?;
+        match cell {
+            Cell::Code {
+                source,
+                execution_count,
+                ..
+            } => {
+                *source = new_source;
+                *execution_count = None;
+                updates.push("source replaced".to_string());
+            }
+            Cell::Markdown { source, .. } => {
+                *source = new_source;
+                updates.push("source replaced".to_string());
+            }
+            Cell::Raw { source, .. } => {
+                *source = new_source;
+                updates.push("source replaced".to_string());
+            }
+        }
+    }
+
+    if let Some(ref append_text) = args.append {
+        let append_source = common::parse_source(append_text)?;
+        match cell {
+            Cell::Code {
+                source,
+                execution_count,
+                ..
+            } => {
+                source.extend(append_source);
+                *execution_count = None;
+                updates.push("source appended".to_string());
+            }
+            Cell::Markdown { source, .. } => {
+                source.extend(append_source);
+                updates.push("source appended".to_string());
+            }
+            Cell::Raw { source, .. } => {
+                source.extend(append_source);
+                updates.push("source appended".to_string());
+            }
+        }
+    }
+
+    if let Some(new_type) = args.cell_type {
+        let old_cell = notebook.cells.remove(index);
+        let (old_id, old_metadata, old_source) = match old_cell {
+            Cell::Code {
+                id,
+                metadata,
+                source,
+                ..
+            } => (id, metadata, source),
+            Cell::Markdown {
+                id,
+                metadata,
+                source,
+                ..
+            } => (id, metadata, source),
+            Cell::Raw {
+                id,
+                metadata,
+                source,
+            } => (id, metadata, source),
+        };
+
+        let new_cell = match new_type {
+            CellType::Code => Cell::Code {
+                id: old_id,
+                metadata: old_metadata,
+                execution_count: None,
+                source: old_source,
+                outputs: vec![],
+            },
+            CellType::Markdown => Cell::Markdown {
+                id: old_id,
+                metadata: old_metadata,
+                source: old_source,
+                attachments: None,
+            },
+            CellType::Raw => Cell::Raw {
+                id: old_id,
+                metadata: old_metadata,
+                source: old_source,
+            },
+        };
+
+        notebook.cells.insert(index, new_cell);
+        let type_name = match new_type {
+            CellType::Code => "code",
+            CellType::Markdown => "markdown",
+            CellType::Raw => "raw",
+        };
+        updates.push(format!("type changed to {}", type_name));
+    }
+
+    client
+        .save_notebook(&notebook_server_path, &notebook)
+        .await
+        .context("Failed to save notebook to server")?;
+
+    let result = UpdateCellResult {
+        file: file_path,
         cell_id,
         index,
         updated: updates,

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -87,7 +87,7 @@ pub fn execute(args: UpdateCellArgs) -> Result<()> {
     let mode = common::resolve_execution_mode(args.server.clone(), args.token.clone())?;
 
     match &mode {
-        ExecutionMode::Local => execute_file_based(args),
+        ExecutionMode::Local | ExecutionMode::RemoteKernel { .. } => execute_file_based(args),
         ExecutionMode::Remote { .. } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -201,7 +201,7 @@ async fn execute_with_contents_api(
     use nbformat::v4::Cell;
 
     let file = args.file.clone();
-    common::with_contents_api(&file, &mode, |notebook, file_path| {
+    let result = common::with_contents_api(&file, &mode, |notebook, file_path| {
         let (index, cell_id) = if let Some(ref id) = args.cell {
             let (idx, cell) = common::find_cell_by_id(&notebook.cells, id)?;
             (idx, cell.id().to_string())
@@ -314,23 +314,21 @@ async fn execute_with_contents_api(
             updates.push(format!("type changed to {}", type_name));
         }
 
-        let result = UpdateCellResult {
+        Ok(UpdateCellResult {
             file: file_path.to_string(),
             cell_id,
             index,
             updated: updates,
-        };
-
-        let format = if args.json {
-            OutputFormat::Json
-        } else {
-            OutputFormat::Text
-        };
-        output_result(&result, &format)?;
-
-        Ok(())
+        })
     })
-    .await
+    .await?;
+
+    let format = if args.json {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+    output_result(&result, &format)
 }
 
 fn execute_file_based(args: UpdateCellArgs) -> Result<()> {

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -88,15 +88,23 @@ pub fn execute(args: UpdateCellArgs) -> Result<()> {
 
     match &mode {
         ExecutionMode::Local => execute_file_based(args),
-        ExecutionMode::Remote { .. } => {
-            let ydoc_available = common::resolve_ydoc_available(&args.server, &args.token);
+        ExecutionMode::Remote {
+            ref server_url,
+            ref token,
+        } => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            if ydoc_available == Some(false) {
-                runtime.block_on(execute_with_contents_api(args, mode))
-            } else {
+            let ydoc = runtime.block_on(common::resolve_ydoc_with_probe(
+                server_url,
+                token,
+                &args.server,
+                &args.token,
+            ));
+            if ydoc {
                 runtime.block_on(execute_with_realtime(args, mode))
+            } else {
+                runtime.block_on(execute_with_contents_api(args, mode))
             }
         }
     }

--- a/src/commands/update_cell.rs
+++ b/src/commands/update_cell.rs
@@ -200,158 +200,137 @@ async fn execute_with_contents_api(
 ) -> Result<()> {
     use nbformat::v4::Cell;
 
-    let (server_url, token) = match &mode {
-        crate::execution::types::ExecutionMode::Remote { server_url, token } => {
-            (server_url.clone(), token.clone())
-        }
-        _ => bail!("Expected remote execution mode"),
-    };
-
-    let file_path = common::normalize_notebook_path(&args.file);
-    let server_root = common::resolve_server_root();
-    let notebook_server_path = common::notebook_path_for_server(&file_path, server_root.as_deref());
-
-    let client = crate::execution::remote::client::JupyterClient::new(
-        server_url.clone(),
-        token.clone(),
-    )?;
-    let mut notebook = client
-        .get_notebook(&notebook_server_path)
-        .await
-        .context("Failed to read notebook from server")?;
-
-    let (index, cell_id) = if let Some(ref id) = args.cell {
-        let (idx, cell) = common::find_cell_by_id(&notebook.cells, id)?;
-        (idx, cell.id().to_string())
-    } else if let Some(cell_index) = args.cell_index {
-        let idx = common::normalize_index(cell_index, notebook.cells.len())?;
-        let id = notebook.cells[idx].id().to_string();
-        (idx, id)
-    } else {
-        unreachable!("Already validated cell selector");
-    };
-
-    let mut updates = Vec::new();
-    let cell = &mut notebook.cells[index];
-
-    if let Some(ref source_text) = args.source {
-        let new_source = common::parse_source(source_text)?;
-        match cell {
-            Cell::Code {
-                source,
-                execution_count,
-                ..
-            } => {
-                *source = new_source;
-                *execution_count = None;
-                updates.push("source replaced".to_string());
-            }
-            Cell::Markdown { source, .. } => {
-                *source = new_source;
-                updates.push("source replaced".to_string());
-            }
-            Cell::Raw { source, .. } => {
-                *source = new_source;
-                updates.push("source replaced".to_string());
-            }
-        }
-    }
-
-    if let Some(ref append_text) = args.append {
-        let append_source = common::parse_source(append_text)?;
-        match cell {
-            Cell::Code {
-                source,
-                execution_count,
-                ..
-            } => {
-                source.extend(append_source);
-                *execution_count = None;
-                updates.push("source appended".to_string());
-            }
-            Cell::Markdown { source, .. } => {
-                source.extend(append_source);
-                updates.push("source appended".to_string());
-            }
-            Cell::Raw { source, .. } => {
-                source.extend(append_source);
-                updates.push("source appended".to_string());
-            }
-        }
-    }
-
-    if let Some(new_type) = args.cell_type {
-        let old_cell = notebook.cells.remove(index);
-        let (old_id, old_metadata, old_source) = match old_cell {
-            Cell::Code {
-                id,
-                metadata,
-                source,
-                ..
-            } => (id, metadata, source),
-            Cell::Markdown {
-                id,
-                metadata,
-                source,
-                ..
-            } => (id, metadata, source),
-            Cell::Raw {
-                id,
-                metadata,
-                source,
-            } => (id, metadata, source),
+    let file = args.file.clone();
+    common::with_contents_api(&file, &mode, |notebook, file_path| {
+        let (index, cell_id) = if let Some(ref id) = args.cell {
+            let (idx, cell) = common::find_cell_by_id(&notebook.cells, id)?;
+            (idx, cell.id().to_string())
+        } else if let Some(cell_index) = args.cell_index {
+            let idx = common::normalize_index(cell_index, notebook.cells.len())?;
+            let id = notebook.cells[idx].id().to_string();
+            (idx, id)
+        } else {
+            unreachable!("Already validated cell selector");
         };
 
-        let new_cell = match new_type {
-            CellType::Code => Cell::Code {
-                id: old_id,
-                metadata: old_metadata,
-                execution_count: None,
-                source: old_source,
-                outputs: vec![],
-            },
-            CellType::Markdown => Cell::Markdown {
-                id: old_id,
-                metadata: old_metadata,
-                source: old_source,
-                attachments: None,
-            },
-            CellType::Raw => Cell::Raw {
-                id: old_id,
-                metadata: old_metadata,
-                source: old_source,
-            },
+        let mut updates = Vec::new();
+        let cell = &mut notebook.cells[index];
+
+        if let Some(ref source_text) = args.source {
+            let new_source = common::parse_source(source_text)?;
+            match cell {
+                Cell::Code {
+                    source,
+                    execution_count,
+                    ..
+                } => {
+                    *source = new_source;
+                    *execution_count = None;
+                    updates.push("source replaced".to_string());
+                }
+                Cell::Markdown { source, .. } => {
+                    *source = new_source;
+                    updates.push("source replaced".to_string());
+                }
+                Cell::Raw { source, .. } => {
+                    *source = new_source;
+                    updates.push("source replaced".to_string());
+                }
+            }
+        }
+
+        if let Some(ref append_text) = args.append {
+            let append_source = common::parse_source(append_text)?;
+            match cell {
+                Cell::Code {
+                    source,
+                    execution_count,
+                    ..
+                } => {
+                    source.extend(append_source);
+                    *execution_count = None;
+                    updates.push("source appended".to_string());
+                }
+                Cell::Markdown { source, .. } => {
+                    source.extend(append_source);
+                    updates.push("source appended".to_string());
+                }
+                Cell::Raw { source, .. } => {
+                    source.extend(append_source);
+                    updates.push("source appended".to_string());
+                }
+            }
+        }
+
+        if let Some(new_type) = args.cell_type {
+            let old_cell = notebook.cells.remove(index);
+            let (old_id, old_metadata, old_source) = match old_cell {
+                Cell::Code {
+                    id,
+                    metadata,
+                    source,
+                    ..
+                } => (id, metadata, source),
+                Cell::Markdown {
+                    id,
+                    metadata,
+                    source,
+                    ..
+                } => (id, metadata, source),
+                Cell::Raw {
+                    id,
+                    metadata,
+                    source,
+                } => (id, metadata, source),
+            };
+
+            let new_cell = match new_type {
+                CellType::Code => Cell::Code {
+                    id: old_id,
+                    metadata: old_metadata,
+                    execution_count: None,
+                    source: old_source,
+                    outputs: vec![],
+                },
+                CellType::Markdown => Cell::Markdown {
+                    id: old_id,
+                    metadata: old_metadata,
+                    source: old_source,
+                    attachments: None,
+                },
+                CellType::Raw => Cell::Raw {
+                    id: old_id,
+                    metadata: old_metadata,
+                    source: old_source,
+                },
+            };
+
+            notebook.cells.insert(index, new_cell);
+            let type_name = match new_type {
+                CellType::Code => "code",
+                CellType::Markdown => "markdown",
+                CellType::Raw => "raw",
+            };
+            updates.push(format!("type changed to {}", type_name));
+        }
+
+        let result = UpdateCellResult {
+            file: file_path.to_string(),
+            cell_id,
+            index,
+            updated: updates,
         };
 
-        notebook.cells.insert(index, new_cell);
-        let type_name = match new_type {
-            CellType::Code => "code",
-            CellType::Markdown => "markdown",
-            CellType::Raw => "raw",
+        let format = if args.json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
         };
-        updates.push(format!("type changed to {}", type_name));
-    }
+        output_result(&result, &format)?;
 
-    client
-        .save_notebook(&notebook_server_path, &notebook)
-        .await
-        .context("Failed to save notebook to server")?;
-
-    let result = UpdateCellResult {
-        file: file_path,
-        cell_id,
-        index,
-        updated: updates,
-    };
-
-    let format = if args.json {
-        OutputFormat::Json
-    } else {
-        OutputFormat::Text
-    };
-    output_result(&result, &format)?;
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 fn execute_file_based(args: UpdateCellArgs) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,6 +17,10 @@ pub struct JupyterConnection {
     /// Project root path for uv/pixi environments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_root: Option<String>,
+    /// Whether Y.js/collaboration backend is available on the server.
+    /// None means unknown (treated as true for backward compat).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ydoc_available: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,8 @@ pub struct JupyterConnection {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_root: Option<String>,
     /// Whether Y.js/collaboration backend is available on the server.
-    /// None means unknown (treated as true for backward compat).
+    /// None means unknown: commands probe the server live, and execution
+    /// tries Y.js with a fallback to the kernel-WS path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ydoc_available: Option<bool>,
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -38,6 +38,13 @@ pub trait ExecutionBackend: Send {
         on_output: Option<&OutputCallback>,
     ) -> Result<ExecutionResult>;
 
+    /// Whether the server persists executed outputs itself (Y.js room
+    /// attached). When false in remote mode, the caller must save the
+    /// notebook via the Contents API after execution.
+    fn server_persists_outputs(&self) -> bool {
+        false
+    }
+
     /// Stop the backend (cleanup kernel or close session)
     async fn stop(&mut self) -> Result<()>;
 }

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -382,13 +382,15 @@ impl JupyterClient {
         Ok(())
     }
 
-    /// Probe whether the Y.js/collaboration backend (FileID API) is available.
-    /// Returns true if the server has jupyter-collaboration/jupyter-server-documents.
+    /// Probe whether the Y.js backend (jupyter-server-documents) is available.
+    /// Uses POST /api/fileid/index, which only jupyter-server-documents registers.
+    /// GET /api/fileid/id cannot be used: it returns 404 for unindexed paths
+    /// even when the fileid extension is installed.
     pub async fn probe_ydoc(&self) -> Result<bool> {
-        let url = format!("{}/api/fileid/id", self.base_url);
+        let url = format!("{}/api/fileid/index", self.base_url);
         let response = self
             .client
-            .get(&url)
+            .post(&url)
             .query(&[("token", self.token.as_str()), ("path", "probe")])
             .send()
             .await

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -388,10 +388,14 @@ impl JupyterClient {
     /// even when the fileid extension is installed.
     ///
     /// jupyter-collaboration servers intentionally probe as unavailable: our
-    /// Y.js room handshake is not compatible with them, so they are served via
-    /// the Contents API path instead. The probe indexes a junk "probe" path as
-    /// a side effect; jupyter-server-documents' default ArbitraryFileIdManager
-    /// accepts paths that don't exist on disk (verified against 0.2.2).
+    /// Y.js room handshake is not compatible with them today, so they are
+    /// served via the Contents API path. The collab-session fallback in
+    /// ydoc.rs `get_file_id` is kept for when a compatible handshake lands.
+    ///
+    /// The probe indexes a junk "probe" path as a side effect. The default
+    /// ArbitraryFileIdManager accepts paths that don't exist on disk (verified
+    /// against jupyter-server-documents 0.2.2); a non-default manager that
+    /// rejects nonexistent paths would make this probe false-negative.
     pub async fn probe_ydoc(&self) -> Result<bool> {
         let url = format!("{}/api/fileid/index", self.base_url);
         let response = self

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -386,6 +386,12 @@ impl JupyterClient {
     /// Uses POST /api/fileid/index, which only jupyter-server-documents registers.
     /// GET /api/fileid/id cannot be used: it returns 404 for unindexed paths
     /// even when the fileid extension is installed.
+    ///
+    /// jupyter-collaboration servers intentionally probe as unavailable: our
+    /// Y.js room handshake is not compatible with them, so they are served via
+    /// the Contents API path instead. The probe indexes a junk "probe" path as
+    /// a side effect; jupyter-server-documents' default ArbitraryFileIdManager
+    /// accepts paths that don't exist on disk (verified against 0.2.2).
     pub async fn probe_ydoc(&self) -> Result<bool> {
         let url = format!("{}/api/fileid/index", self.base_url);
         let response = self

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -394,7 +394,14 @@ impl JupyterClient {
             .await
             .context("Failed to probe FileID API")?;
 
-        Ok(response.status().as_u16() != 404)
+        let status = response.status();
+        if status.as_u16() == 404 {
+            Ok(false)
+        } else if status.is_success() || status.is_redirection() {
+            Ok(true)
+        } else {
+            anyhow::bail!("FileID probe returned unexpected status {}", status)
+        }
     }
 
     /// Get the WebSocket URL for a kernel

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -355,7 +355,6 @@ impl JupyterClient {
     }
 
     /// Save a notebook to the server
-    #[allow(dead_code)]
     pub async fn save_notebook(&self, path: &str, notebook: &nbformat::v4::Notebook) -> Result<()> {
         let url = self.contents_url(path)?;
 
@@ -381,6 +380,21 @@ impl JupyterClient {
         }
 
         Ok(())
+    }
+
+    /// Probe whether the Y.js/collaboration backend (FileID API) is available.
+    /// Returns true if the server has jupyter-collaboration/jupyter-server-documents.
+    pub async fn probe_ydoc(&self) -> Result<bool> {
+        let url = format!("{}/api/fileid/id", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("token", self.token.as_str()), ("path", "probe")])
+            .send()
+            .await
+            .context("Failed to probe FileID API")?;
+
+        Ok(response.status().as_u16() != 404)
     }
 
     /// Get the WebSocket URL for a kernel

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -387,10 +387,10 @@ impl JupyterClient {
     /// GET /api/fileid/id cannot be used: it returns 404 for unindexed paths
     /// even when the fileid extension is installed.
     ///
-    /// jupyter-collaboration servers intentionally probe as unavailable: our
-    /// Y.js room handshake is not compatible with them today, so they are
-    /// served via the Contents API path. The collab-session fallback in
-    /// ydoc.rs `get_file_id` is kept for when a compatible handshake lands.
+    /// This probe checks only fileid/index, so jupyter-collaboration servers
+    /// (which 404 it) are cached Some(false) and served via the Contents API
+    /// path. ydoc.rs `get_file_id` keeps a separate collaboration/session
+    /// fallback that #95 extends for full jupyter-collaboration support.
     ///
     /// Probes with the server root path, which always exists, so the index
     /// call is idempotent and creates no record for a fake path. Verified

--- a/src/execution/remote/client.rs
+++ b/src/execution/remote/client.rs
@@ -392,16 +392,16 @@ impl JupyterClient {
     /// served via the Contents API path. The collab-session fallback in
     /// ydoc.rs `get_file_id` is kept for when a compatible handshake lands.
     ///
-    /// The probe indexes a junk "probe" path as a side effect. The default
-    /// ArbitraryFileIdManager accepts paths that don't exist on disk (verified
-    /// against jupyter-server-documents 0.2.2); a non-default manager that
-    /// rejects nonexistent paths would make this probe false-negative.
+    /// Probes with the server root path, which always exists, so the index
+    /// call is idempotent and creates no record for a fake path. Verified
+    /// against jupyter-server-documents 0.2.2 with both ArbitraryFileIdManager
+    /// and LocalFileIdManager: both return 200 for the root path.
     pub async fn probe_ydoc(&self) -> Result<bool> {
         let url = format!("{}/api/fileid/index", self.base_url);
         let response = self
             .client
             .post(&url)
-            .query(&[("token", self.token.as_str()), ("path", "probe")])
+            .query(&[("token", self.token.as_str()), ("path", "")])
             .send()
             .await
             .context("Failed to probe FileID API")?;

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -172,23 +172,31 @@ impl RemoteExecutor {
                         );
                     }
                     kernel_msg = ws.recv_message() => {
-                        if let Some(msg) = kernel_msg? {
-                            let is_ours = msg.parent_header.as_ref()
-                                .map(|h| h.msg_id == msg_id).unwrap_or(false);
-                            if is_ours {
-                                match &msg.content {
-                                    JupyterMessageContent::ExecuteInput(input) => {
-                                        expected_ec = Some(input.execution_count.0 as i64);
-                                    }
-                                    JupyterMessageContent::Status(status) => {
-                                        if matches!(status.execution_state,
-                                            jupyter_protocol::ExecutionState::Idle) {
-                                            idle_received = true;
+                        match kernel_msg? {
+                            Some(msg) => {
+                                let is_ours = msg.parent_header.as_ref()
+                                    .map(|h| h.msg_id == msg_id).unwrap_or(false);
+                                if is_ours {
+                                    match &msg.content {
+                                        JupyterMessageContent::ExecuteInput(input) => {
+                                            expected_ec = Some(input.execution_count.0 as i64);
                                         }
+                                        JupyterMessageContent::Status(status) => {
+                                            if matches!(status.execution_state,
+                                                jupyter_protocol::ExecutionState::Idle) {
+                                                idle_received = true;
+                                            }
+                                        }
+                                        _ => {}
                                     }
-                                    _ => {}
                                 }
                             }
+                            // A closed socket yields None on every recv; without
+                            // this arm the select busy-spins until the deadline
+                            // and misreports the drop as a timeout.
+                            None => anyhow::bail!(
+                                "Kernel WebSocket closed before execution completed"
+                            ),
                         }
                     }
                     ydoc_result = ydoc.recv_update() => {
@@ -952,10 +960,14 @@ mod kernel_ws_execute_tests {
             ),
             Err(e) => e,
         };
+        // Three legitimate error paths depending on when the peer reset is
+        // observed: detected on recv (closed-before-completed), surfaced as a
+        // read error, or hit during the send itself.
         assert!(
             err.to_string()
                 .contains("closed before execution completed")
-                || err.to_string().contains("WebSocket error"),
+                || err.to_string().contains("WebSocket error")
+                || err.to_string().contains("Failed to send execute request"),
             "unexpected error: {}",
             err
         );

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -492,9 +492,13 @@ impl ExecutionBackend for RemoteExecutor {
         self.session = Some(session);
         self.ws = Some(ws);
 
-        // Connect Y.js client for observing outputs during execution (skip for vanilla servers)
-        let skip_ydoc = self.config.ydoc_available == Some(false);
-        if !skip_ydoc {
+        // Connect Y.js client for observing outputs during execution.
+        // The cached ydoc_available is a routing hint, not a gate: Some(false)
+        // skips the attempt, anything else tries Y.js and falls back to the
+        // kernel-WS path on the definitive backend-absent signal. Transient
+        // errors stay hard so a flaky collaboration server is never silently
+        // downgraded.
+        if self.config.ydoc_available != Some(false) {
             if let Some(ref notebook_path) = self.config.notebook_path {
                 match YDocClient::connect(
                     self.server_url.clone(),
@@ -506,13 +510,17 @@ impl ExecutionBackend for RemoteExecutor {
                     Ok(ydoc) => {
                         self.ydoc = Some(ydoc);
                     }
-                    Err(e) => {
-                        if self.config.ydoc_available.is_none() {
-                            eprintln!("Y.js not available, using direct kernel output: {}", e);
-                        } else {
-                            return Err(e)
-                                .context("Failed to connect Y.js client for output observation");
+                    Err(e) if ydoc::is_yjs_unavailable(&e) => {
+                        if self.config.ydoc_available == Some(true) {
+                            eprintln!(
+                                "Collaboration backend no longer found on server; \
+                                 using direct kernel output. Run 'nb connect' to refresh."
+                            );
                         }
+                    }
+                    Err(e) => {
+                        return Err(e)
+                            .context("Failed to connect Y.js client for output observation");
                     }
                 }
             }
@@ -534,6 +542,12 @@ impl ExecutionBackend for RemoteExecutor {
         } else {
             self.execute_code_kernel_ws(code, cell_id, on_output).await
         }
+    }
+
+    fn server_persists_outputs(&self) -> bool {
+        // With a Y.js room attached, the server observes and saves outputs
+        // itself; without one the caller must persist via the Contents API.
+        self.ydoc.is_some()
     }
 
     async fn stop(&mut self) -> Result<()> {

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -219,12 +219,7 @@ impl RemoteExecutor {
             .send_execute_request(code, !self.config.allow_errors, cell_id)
             .await?;
 
-        let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
-        let mut execution_count: Option<i64> = None;
-        let mut error_info: Option<ExecutionError> = None;
-        // Set by clear_output(wait=True): defer the clear until the next
-        // output arrives, keeping current outputs if none follows.
-        let mut clear_pending = false;
+        let mut collector = KernelOutputCollector::new();
 
         loop {
             let msg = match tokio::time::timeout_at(deadline, ws.recv_message()).await {
@@ -244,125 +239,166 @@ impl RemoteExecutor {
                 continue;
             }
 
-            // Apply a deferred clear_output(wait=True) when the next output arrives
-            if clear_pending
-                && matches!(
-                    msg.content,
-                    JupyterMessageContent::StreamContent(_)
-                        | JupyterMessageContent::ExecuteResult(_)
-                        | JupyterMessageContent::DisplayData(_)
-                        | JupyterMessageContent::ErrorOutput(_)
-                )
-            {
-                outputs.clear();
-                clear_pending = false;
-            }
-
-            match msg.content {
-                JupyterMessageContent::Status(status)
-                    if matches!(
-                        status.execution_state,
-                        jupyter_protocol::ExecutionState::Idle
-                    ) =>
-                {
-                    break;
-                }
-                JupyterMessageContent::StreamContent(stream) => {
-                    let name = match stream.name {
-                        jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
-                        jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
-                    };
-                    if let Some(cb) = &on_output {
-                        let chunk = nbformat::v4::Output::Stream {
-                            name: name.clone(),
-                            text: nbformat::v4::MultilineString(stream.text.clone()),
-                        };
-                        cb(&chunk);
-                    }
-                    // Merge consecutive same-name stream outputs into one entry
-                    let coalesced = if let Some(nbformat::v4::Output::Stream {
-                        name: ref last_name,
-                        text: ref mut last_text,
-                    }) = outputs.last_mut()
-                    {
-                        if *last_name == name {
-                            last_text.0.push_str(&stream.text);
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
-                    if !coalesced {
-                        outputs.push(nbformat::v4::Output::Stream {
-                            name,
-                            text: nbformat::v4::MultilineString(stream.text),
-                        });
-                    }
-                }
-                JupyterMessageContent::ExecuteResult(result) => {
-                    execution_count = Some(result.execution_count.value() as i64);
-                    let json = serde_json::json!({
-                        "output_type": "execute_result",
-                        "execution_count": result.execution_count.value(),
-                        "data": result.data,
-                        "metadata": result.metadata
-                    });
-                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
-                        if let Some(cb) = &on_output {
-                            cb(&output);
-                        }
-                        outputs.push(output);
-                    }
-                }
-                JupyterMessageContent::DisplayData(display) => {
-                    let json = serde_json::json!({
-                        "output_type": "display_data",
-                        "data": display.data,
-                        "metadata": display.metadata
-                    });
-                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
-                        if let Some(cb) = &on_output {
-                            cb(&output);
-                        }
-                        outputs.push(output);
-                    }
-                }
-                JupyterMessageContent::ErrorOutput(error) => {
-                    error_info = Some(ExecutionError {
-                        ename: error.ename.clone(),
-                        evalue: error.evalue.clone(),
-                        traceback: error.traceback.clone(),
-                    });
-                    let output = nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
-                        ename: error.ename,
-                        evalue: error.evalue,
-                        traceback: error.traceback,
-                    });
-                    if let Some(cb) = &on_output {
-                        cb(&output);
-                    }
-                    outputs.push(output);
-                }
-                JupyterMessageContent::ClearOutput(clear) => {
-                    if clear.wait {
-                        clear_pending = true;
-                    } else {
-                        outputs.clear();
-                    }
-                }
-                JupyterMessageContent::ExecuteInput(input) => {
-                    execution_count = Some(input.execution_count.0 as i64);
-                }
-                _ => {}
+            if collector.handle(msg.content, on_output) {
+                break;
             }
         }
 
-        if let Some(error) = error_info {
-            Ok(ExecutionResult::error(outputs, execution_count, error))
+        Ok(collector.into_result())
+    }
+}
+
+/// Accumulates nbformat outputs from a kernel iopub message stream, applying
+/// the same persistence semantics as nbclient: consecutive same-name stream
+/// outputs are coalesced into one entry, clear_output is applied immediately,
+/// and clear_output(wait=True) is deferred until the next output arrives so
+/// that outputs are kept when nothing follows.
+struct KernelOutputCollector {
+    outputs: Vec<nbformat::v4::Output>,
+    execution_count: Option<i64>,
+    error_info: Option<ExecutionError>,
+    clear_pending: bool,
+}
+
+impl KernelOutputCollector {
+    fn new() -> Self {
+        Self {
+            outputs: Vec::new(),
+            execution_count: None,
+            error_info: None,
+            clear_pending: false,
+        }
+    }
+
+    /// Process one kernel message belonging to the tracked execution.
+    /// Returns true when the kernel reports idle, completing the collection.
+    fn handle(
+        &mut self,
+        content: JupyterMessageContent,
+        on_output: Option<&crate::execution::OutputCallback>,
+    ) -> bool {
+        // Apply a deferred clear_output(wait=True) when the next output arrives
+        if self.clear_pending
+            && matches!(
+                content,
+                JupyterMessageContent::StreamContent(_)
+                    | JupyterMessageContent::ExecuteResult(_)
+                    | JupyterMessageContent::DisplayData(_)
+                    | JupyterMessageContent::ErrorOutput(_)
+            )
+        {
+            self.outputs.clear();
+            self.clear_pending = false;
+        }
+
+        match content {
+            JupyterMessageContent::Status(status)
+                if matches!(
+                    status.execution_state,
+                    jupyter_protocol::ExecutionState::Idle
+                ) =>
+            {
+                return true;
+            }
+            JupyterMessageContent::StreamContent(stream) => {
+                let name = match stream.name {
+                    jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
+                    jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
+                };
+                if let Some(cb) = &on_output {
+                    let chunk = nbformat::v4::Output::Stream {
+                        name: name.clone(),
+                        text: nbformat::v4::MultilineString(stream.text.clone()),
+                    };
+                    cb(&chunk);
+                }
+                // Merge consecutive same-name stream outputs into one entry
+                let coalesced = if let Some(nbformat::v4::Output::Stream {
+                    name: ref last_name,
+                    text: ref mut last_text,
+                }) = self.outputs.last_mut()
+                {
+                    if *last_name == name {
+                        last_text.0.push_str(&stream.text);
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+                if !coalesced {
+                    self.outputs.push(nbformat::v4::Output::Stream {
+                        name,
+                        text: nbformat::v4::MultilineString(stream.text),
+                    });
+                }
+            }
+            JupyterMessageContent::ExecuteResult(result) => {
+                self.execution_count = Some(result.execution_count.value() as i64);
+                let json = serde_json::json!({
+                    "output_type": "execute_result",
+                    "execution_count": result.execution_count.value(),
+                    "data": result.data,
+                    "metadata": result.metadata
+                });
+                if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                    if let Some(cb) = &on_output {
+                        cb(&output);
+                    }
+                    self.outputs.push(output);
+                }
+            }
+            JupyterMessageContent::DisplayData(display) => {
+                let json = serde_json::json!({
+                    "output_type": "display_data",
+                    "data": display.data,
+                    "metadata": display.metadata
+                });
+                if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                    if let Some(cb) = &on_output {
+                        cb(&output);
+                    }
+                    self.outputs.push(output);
+                }
+            }
+            JupyterMessageContent::ErrorOutput(error) => {
+                self.error_info = Some(ExecutionError {
+                    ename: error.ename.clone(),
+                    evalue: error.evalue.clone(),
+                    traceback: error.traceback.clone(),
+                });
+                let output = nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
+                    ename: error.ename,
+                    evalue: error.evalue,
+                    traceback: error.traceback,
+                });
+                if let Some(cb) = &on_output {
+                    cb(&output);
+                }
+                self.outputs.push(output);
+            }
+            JupyterMessageContent::ClearOutput(clear) => {
+                if clear.wait {
+                    self.clear_pending = true;
+                } else {
+                    self.outputs.clear();
+                }
+            }
+            JupyterMessageContent::ExecuteInput(input) => {
+                self.execution_count = Some(input.execution_count.0 as i64);
+            }
+            _ => {}
+        }
+
+        false
+    }
+
+    fn into_result(self) -> ExecutionResult {
+        if let Some(error) = self.error_info {
+            ExecutionResult::error(self.outputs, self.execution_count, error)
         } else {
-            Ok(ExecutionResult::success(outputs, execution_count))
+            ExecutionResult::success(self.outputs, self.execution_count)
         }
     }
 }
@@ -503,5 +539,207 @@ impl ExecutionBackend for RemoteExecutor {
         // stay alive across multiple cell executions.
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod kernel_output_collector_tests {
+    use super::*;
+    use jupyter_protocol::{
+        ClearOutput, ExecutionCount, ExecutionState, Status, Stdio, StreamContent,
+    };
+
+    fn stream(name: Stdio, text: &str) -> JupyterMessageContent {
+        JupyterMessageContent::StreamContent(StreamContent {
+            name,
+            text: text.to_string(),
+        })
+    }
+
+    fn clear(wait: bool) -> JupyterMessageContent {
+        JupyterMessageContent::ClearOutput(ClearOutput { wait })
+    }
+
+    fn status(execution_state: ExecutionState) -> JupyterMessageContent {
+        JupyterMessageContent::Status(Status { execution_state })
+    }
+
+    fn execute_result(ec: usize, plain_text: &str) -> JupyterMessageContent {
+        JupyterMessageContent::ExecuteResult(jupyter_protocol::ExecuteResult {
+            execution_count: ExecutionCount::new(ec),
+            data: serde_json::from_value(serde_json::json!({ "text/plain": plain_text })).unwrap(),
+            metadata: serde_json::Map::new(),
+            transient: None,
+        })
+    }
+
+    fn error(ename: &str, evalue: &str) -> JupyterMessageContent {
+        JupyterMessageContent::ErrorOutput(jupyter_protocol::ErrorOutput {
+            ename: ename.to_string(),
+            evalue: evalue.to_string(),
+            traceback: vec![format!("{}: {}", ename, evalue)],
+        })
+    }
+
+    /// Feed a message sequence and return the final result, asserting that
+    /// only a trailing Idle completes the collection.
+    fn collect(messages: Vec<JupyterMessageContent>) -> ExecutionResult {
+        let mut collector = KernelOutputCollector::new();
+        let last = messages.len() - 1;
+        for (i, msg) in messages.into_iter().enumerate() {
+            let is_idle = matches!(
+                &msg,
+                JupyterMessageContent::Status(s) if s.execution_state == ExecutionState::Idle
+            );
+            let done = collector.handle(msg, None);
+            assert_eq!(done, is_idle, "only Idle should complete (message {})", i);
+            if done {
+                assert_eq!(
+                    i, last,
+                    "Idle must be the last message in the test sequence"
+                );
+            }
+        }
+        collector.into_result()
+    }
+
+    fn stream_texts(result: &ExecutionResult) -> Vec<(String, String)> {
+        result
+            .outputs
+            .iter()
+            .map(|o| match o {
+                nbformat::v4::Output::Stream { name, text } => (name.clone(), text.0.clone()),
+                other => panic!("expected stream output, got {:?}", other),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn coalesces_consecutive_same_name_streams() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "a\n"),
+            stream(Stdio::Stdout, "b\n"),
+            stream(Stdio::Stdout, "c\n"),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![("stdout".to_string(), "a\nb\nc\n".to_string())]
+        );
+    }
+
+    #[test]
+    fn streams_with_different_names_stay_separate() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "out1"),
+            stream(Stdio::Stderr, "err"),
+            stream(Stdio::Stdout, "out2"),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![
+                ("stdout".to_string(), "out1".to_string()),
+                ("stderr".to_string(), "err".to_string()),
+                ("stdout".to_string(), "out2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn immediate_clear_drops_prior_outputs() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "before"),
+            clear(false),
+            stream(Stdio::Stdout, "after"),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![("stdout".to_string(), "after".to_string())]
+        );
+    }
+
+    #[test]
+    fn deferred_clear_applies_at_next_output() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "frame 0"),
+            clear(true),
+            stream(Stdio::Stdout, "frame 1"),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![("stdout".to_string(), "frame 1".to_string())]
+        );
+    }
+
+    #[test]
+    fn trailing_deferred_clear_keeps_outputs() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "kept"),
+            clear(true),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![("stdout".to_string(), "kept".to_string())]
+        );
+    }
+
+    #[test]
+    fn error_produces_error_result_with_output() {
+        let result = collect(vec![
+            error("ZeroDivisionError", "division by zero"),
+            status(ExecutionState::Idle),
+        ]);
+        assert!(!result.success);
+        let err = result.error.expect("error info should be set");
+        assert_eq!(err.ename, "ZeroDivisionError");
+        assert!(matches!(
+            result.outputs.as_slice(),
+            [nbformat::v4::Output::Error(e)] if e.ename == "ZeroDivisionError"
+        ));
+    }
+
+    #[test]
+    fn execute_result_sets_execution_count_and_output() {
+        let result = collect(vec![execute_result(3, "42"), status(ExecutionState::Idle)]);
+        assert!(result.success);
+        assert_eq!(result.execution_count, Some(3));
+        assert!(matches!(
+            result.outputs.as_slice(),
+            [nbformat::v4::Output::ExecuteResult(er)] if er.execution_count.0 == 3
+        ));
+    }
+
+    #[test]
+    fn busy_status_and_unrelated_messages_are_ignored() {
+        let result = collect(vec![
+            status(ExecutionState::Busy),
+            JupyterMessageContent::ExecuteInput(jupyter_protocol::ExecuteInput {
+                code: "1 + 1".to_string(),
+                execution_count: ExecutionCount::new(7),
+            }),
+            status(ExecutionState::Idle),
+        ]);
+        assert!(result.success);
+        assert_eq!(result.execution_count, Some(7));
+        assert!(result.outputs.is_empty());
+    }
+
+    #[test]
+    fn clear_starts_a_new_coalescing_run() {
+        let result = collect(vec![
+            stream(Stdio::Stdout, "old"),
+            clear(false),
+            stream(Stdio::Stdout, "new1 "),
+            stream(Stdio::Stdout, "new2"),
+            status(ExecutionState::Idle),
+        ]);
+        assert_eq!(
+            stream_texts(&result),
+            vec![("stdout".to_string(), "new1 new2".to_string())]
+        );
     }
 }

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -754,21 +754,36 @@ mod kernel_output_collector_tests {
 
     #[test]
     fn deferred_clear_flushed_by_each_output_kind() {
-        for flusher in [
-            execute_result(1, "42"),
-            display_data("img"),
-            error("E", "v"),
-        ] {
+        type IsExpected = fn(&nbformat::v4::Output) -> bool;
+        let cases: [(JupyterMessageContent, &str, IsExpected); 3] = [
+            (execute_result(1, "42"), "execute_result", |o| {
+                matches!(o, nbformat::v4::Output::ExecuteResult(_))
+            }),
+            (display_data("img"), "display_data", |o| {
+                matches!(o, nbformat::v4::Output::DisplayData(_))
+            }),
+            (error("E", "v"), "error", |o| {
+                matches!(o, nbformat::v4::Output::Error(_))
+            }),
+        ];
+        for (flusher, label, is_expected) in cases {
             let result = collect(vec![
                 stream(Stdio::Stdout, "stale"),
                 clear(true),
                 flusher,
                 status(ExecutionState::Idle),
             ]);
-            assert_eq!(result.outputs.len(), 1, "stale output should be dropped");
+            assert_eq!(
+                result.outputs.len(),
+                1,
+                "{}: stale output should be dropped",
+                label
+            );
             assert!(
-                !matches!(&result.outputs[0], nbformat::v4::Output::Stream { .. }),
-                "remaining output should be the flushing output, not the stale stream"
+                is_expected(&result.outputs[0]),
+                "{}: remaining output should be the flushing output, got {:?}",
+                label,
+                result.outputs[0]
             );
         }
     }

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -244,6 +244,20 @@ impl RemoteExecutor {
                 continue;
             }
 
+            // Apply a deferred clear_output(wait=True) when the next output arrives
+            if clear_pending
+                && matches!(
+                    msg.content,
+                    JupyterMessageContent::StreamContent(_)
+                        | JupyterMessageContent::ExecuteResult(_)
+                        | JupyterMessageContent::DisplayData(_)
+                        | JupyterMessageContent::ErrorOutput(_)
+                )
+            {
+                outputs.clear();
+                clear_pending = false;
+            }
+
             match msg.content {
                 JupyterMessageContent::Status(status)
                     if matches!(
@@ -254,10 +268,6 @@ impl RemoteExecutor {
                     break;
                 }
                 JupyterMessageContent::StreamContent(stream) => {
-                    if clear_pending {
-                        outputs.clear();
-                        clear_pending = false;
-                    }
                     let name = match stream.name {
                         jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
                         jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
@@ -292,10 +302,6 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::ExecuteResult(result) => {
-                    if clear_pending {
-                        outputs.clear();
-                        clear_pending = false;
-                    }
                     execution_count = Some(result.execution_count.value() as i64);
                     let json = serde_json::json!({
                         "output_type": "execute_result",
@@ -311,10 +317,6 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::DisplayData(display) => {
-                    if clear_pending {
-                        outputs.clear();
-                        clear_pending = false;
-                    }
                     let json = serde_json::json!({
                         "output_type": "display_data",
                         "data": display.data,
@@ -328,10 +330,6 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::ErrorOutput(error) => {
-                    if clear_pending {
-                        outputs.clear();
-                        clear_pending = false;
-                    }
                     error_info = Some(ExecutionError {
                         ename: error.ename.clone(),
                         evalue: error.evalue.clone(),

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -75,6 +75,240 @@ impl RemoteExecutor {
             tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
         }
     }
+
+    /// Y.js-based output collection (collaboration server)
+    async fn execute_code_ydoc(
+        &mut self,
+        code: &str,
+        cell_id: Option<&str>,
+        cell_index: Option<usize>,
+        on_output: Option<&crate::execution::OutputCallback>,
+    ) -> Result<ExecutionResult> {
+        let ws = self.ws.as_mut().context("WebSocket not connected")?;
+        let cell_idx = cell_index.context("cell_index required for remote execution")?;
+        let ydoc = self.ydoc.as_mut().context("Y.js client not connected")?;
+        let http = reqwest::Client::new();
+
+        let msg_id = ws
+            .send_execute_request(code, !self.config.allow_errors, cell_id)
+            .await?;
+
+        let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
+        let mut fetched_urls: HashSet<String> = HashSet::new();
+        let mut seen_indices: HashSet<usize> = HashSet::new();
+        let mut idle_received = false;
+        let mut expected_ec: Option<i64> = None;
+        let deadline = tokio::time::Instant::now() + self.config.timeout;
+
+        loop {
+            let cell_data = ydoc.read_cell_outputs(cell_idx).ok();
+            let ec = cell_data.as_ref().and_then(|d| d.execution_count);
+            let ec_ready = expected_ec.is_some() && ec == expected_ec;
+
+            if ec_ready {
+                if let Some(ref cell_data) = cell_data {
+                    for (idx, url_path) in &cell_data.externalized_urls {
+                        if fetched_urls.insert(url_path.clone()) {
+                            seen_indices.insert(*idx);
+                            if let Some(output) =
+                                Self::fetch_output(&http, &self.server_url, &self.token, url_path)
+                                    .await
+                            {
+                                if let Some(cb) = &on_output {
+                                    cb(&output);
+                                }
+                                outputs.push(output);
+                            }
+                        }
+                    }
+                    for (idx, output) in &cell_data.inline_outputs {
+                        if seen_indices.insert(*idx) {
+                            if let Some(cb) = &on_output {
+                                cb(output);
+                            }
+                            outputs.push(output.clone());
+                        }
+                    }
+                }
+
+                if idle_received {
+                    let has_error = outputs
+                        .iter()
+                        .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
+                    let error_info = outputs.iter().find_map(|o| {
+                        if let nbformat::v4::Output::Error(err) = o {
+                            Some(ExecutionError {
+                                ename: err.ename.clone(),
+                                evalue: err.evalue.clone(),
+                                traceback: err.traceback.clone(),
+                            })
+                        } else {
+                            None
+                        }
+                    });
+                    return if has_error {
+                        Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
+                    } else {
+                        Ok(ExecutionResult::success(outputs, ec))
+                    };
+                }
+            }
+
+            if idle_received {
+                match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => return Err(e).context("Y.js update error"),
+                    Err(_) => break,
+                }
+            } else {
+                tokio::select! {
+                    kernel_msg = ws.recv_message() => {
+                        if let Some(msg) = kernel_msg? {
+                            let is_ours = msg.parent_header.as_ref()
+                                .map(|h| h.msg_id == msg_id).unwrap_or(false);
+                            if is_ours {
+                                match &msg.content {
+                                    JupyterMessageContent::ExecuteInput(input) => {
+                                        expected_ec = Some(input.execution_count.0 as i64);
+                                    }
+                                    JupyterMessageContent::Status(status) => {
+                                        if matches!(status.execution_state,
+                                            jupyter_protocol::ExecutionState::Idle) {
+                                            idle_received = true;
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    ydoc_result = ydoc.recv_update() => {
+                        ydoc_result.context("Y.js update error")?;
+                    }
+                }
+            }
+        }
+
+        let ec = ydoc
+            .read_cell_outputs(cell_idx)
+            .ok()
+            .and_then(|c| c.execution_count);
+        Ok(ExecutionResult::success(outputs, ec))
+    }
+
+    /// Kernel-WS-only output collection (vanilla jupyter_server, no Y.js)
+    async fn execute_code_kernel_ws(
+        &mut self,
+        code: &str,
+        cell_id: Option<&str>,
+        on_output: Option<&crate::execution::OutputCallback>,
+    ) -> Result<ExecutionResult> {
+        let ws = self.ws.as_mut().context("WebSocket not connected")?;
+
+        let msg_id = ws
+            .send_execute_request(code, !self.config.allow_errors, cell_id)
+            .await?;
+
+        let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
+        let mut execution_count: Option<i64> = None;
+        let mut error_info: Option<ExecutionError> = None;
+
+        loop {
+            let msg = match ws.recv_message().await? {
+                Some(msg) => msg,
+                None => break,
+            };
+
+            let is_ours = msg
+                .parent_header
+                .as_ref()
+                .map(|h| h.msg_id == msg_id)
+                .unwrap_or(false);
+
+            if !is_ours {
+                continue;
+            }
+
+            match msg.content {
+                JupyterMessageContent::Status(status)
+                    if matches!(
+                        status.execution_state,
+                        jupyter_protocol::ExecutionState::Idle
+                    ) =>
+                {
+                    break;
+                }
+                JupyterMessageContent::StreamContent(stream) => {
+                    let name = match stream.name {
+                        jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
+                        jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
+                    };
+                    let output = nbformat::v4::Output::Stream {
+                        name,
+                        text: nbformat::v4::MultilineString(stream.text),
+                    };
+                    if let Some(cb) = &on_output {
+                        cb(&output);
+                    }
+                    outputs.push(output);
+                }
+                JupyterMessageContent::ExecuteResult(result) => {
+                    execution_count = Some(result.execution_count.value() as i64);
+                    let json = serde_json::json!({
+                        "output_type": "execute_result",
+                        "execution_count": result.execution_count.value(),
+                        "data": result.data,
+                        "metadata": result.metadata
+                    });
+                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                        if let Some(cb) = &on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+                JupyterMessageContent::DisplayData(display) => {
+                    let json = serde_json::json!({
+                        "output_type": "display_data",
+                        "data": display.data,
+                        "metadata": display.metadata
+                    });
+                    if let Ok(output) = serde_json::from_value::<nbformat::v4::Output>(json) {
+                        if let Some(cb) = &on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+                JupyterMessageContent::ErrorOutput(error) => {
+                    error_info = Some(ExecutionError {
+                        ename: error.ename.clone(),
+                        evalue: error.evalue.clone(),
+                        traceback: error.traceback.clone(),
+                    });
+                    let output = nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
+                        ename: error.ename,
+                        evalue: error.evalue,
+                        traceback: error.traceback,
+                    });
+                    if let Some(cb) = &on_output {
+                        cb(&output);
+                    }
+                    outputs.push(output);
+                }
+                JupyterMessageContent::ExecuteInput(input) => {
+                    execution_count = Some(input.execution_count.0 as i64);
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(error) = error_info {
+            Ok(ExecutionResult::error(outputs, execution_count, error))
+        } else {
+            Ok(ExecutionResult::success(outputs, execution_count))
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -153,16 +387,30 @@ impl ExecutionBackend for RemoteExecutor {
         self.session = Some(session);
         self.ws = Some(ws);
 
-        // Connect Y.js client for observing outputs during execution
-        if let Some(ref notebook_path) = self.config.notebook_path {
-            let ydoc = YDocClient::connect(
-                self.server_url.clone(),
-                self.token.clone(),
-                notebook_path.clone(),
-            )
-            .await
-            .context("Failed to connect Y.js client for output observation")?;
-            self.ydoc = Some(ydoc);
+        // Connect Y.js client for observing outputs during execution (skip for vanilla servers)
+        let skip_ydoc = self.config.ydoc_available == Some(false);
+        if !skip_ydoc {
+            if let Some(ref notebook_path) = self.config.notebook_path {
+                match YDocClient::connect(
+                    self.server_url.clone(),
+                    self.token.clone(),
+                    notebook_path.clone(),
+                )
+                .await
+                {
+                    Ok(ydoc) => {
+                        self.ydoc = Some(ydoc);
+                    }
+                    Err(e) => {
+                        if self.config.ydoc_available.is_none() {
+                            eprintln!("Y.js not available, using direct kernel output: {}", e);
+                        } else {
+                            return Err(e)
+                                .context("Failed to connect Y.js client for output observation");
+                        }
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -175,121 +423,12 @@ impl ExecutionBackend for RemoteExecutor {
         cell_index: Option<usize>,
         on_output: Option<&crate::execution::OutputCallback>,
     ) -> Result<ExecutionResult> {
-        let ws = self.ws.as_mut().context("WebSocket not connected")?;
-        let cell_idx = cell_index.context("cell_index required for remote execution")?;
-        let ydoc = self.ydoc.as_mut().context("Y.js client not connected")?;
-        let http = reqwest::Client::new();
-
-        // 1. Fire execute request
-        let msg_id = ws
-            .send_execute_request(code, !self.config.allow_errors, cell_id)
-            .await?;
-
-        // 2. Watch for changes on the ydoc for this cell
-        let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
-        let mut fetched_urls: HashSet<String> = HashSet::new();
-        let mut seen_indices: HashSet<usize> = HashSet::new();
-        let mut idle_received = false;
-        let mut expected_ec: Option<i64> = None;
-        let deadline = tokio::time::Instant::now() + self.config.timeout;
-
-        loop {
-            // 3. Check ydoc state before blocking — the update may already
-            //    have been applied in a previous iteration.
-            let cell_data = ydoc.read_cell_outputs(cell_idx).ok();
-            let ec = cell_data.as_ref().and_then(|d| d.execution_count);
-            let ec_ready = expected_ec.is_some() && ec == expected_ec;
-
-            if ec_ready {
-                if let Some(ref cell_data) = cell_data {
-                    for (idx, url_path) in &cell_data.externalized_urls {
-                        if fetched_urls.insert(url_path.clone()) {
-                            seen_indices.insert(*idx);
-                            if let Some(output) =
-                                Self::fetch_output(&http, &self.server_url, &self.token, url_path)
-                                    .await
-                            {
-                                if let Some(cb) = &on_output {
-                                    cb(&output);
-                                }
-                                outputs.push(output);
-                            }
-                        }
-                    }
-                    for (idx, output) in &cell_data.inline_outputs {
-                        if seen_indices.insert(*idx) {
-                            if let Some(cb) = &on_output {
-                                cb(output);
-                            }
-                            outputs.push(output.clone());
-                        }
-                    }
-                }
-
-                if idle_received {
-                    let has_error = outputs
-                        .iter()
-                        .any(|o| matches!(o, nbformat::v4::Output::Error(_)));
-                    let error_info = outputs.iter().find_map(|o| {
-                        if let nbformat::v4::Output::Error(err) = o {
-                            Some(ExecutionError {
-                                ename: err.ename.clone(),
-                                evalue: err.evalue.clone(),
-                                traceback: err.traceback.clone(),
-                            })
-                        } else {
-                            None
-                        }
-                    });
-                    return if has_error {
-                        Ok(ExecutionResult::error(outputs, ec, error_info.unwrap()))
-                    } else {
-                        Ok(ExecutionResult::success(outputs, ec))
-                    };
-                }
-            }
-
-            // 4. Wait for new messages
-            if idle_received {
-                match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(e)) => return Err(e).context("Y.js update error"),
-                    Err(_) => break,
-                }
-            } else {
-                tokio::select! {
-                    kernel_msg = ws.recv_message() => {
-                        if let Some(msg) = kernel_msg? {
-                            let is_ours = msg.parent_header.as_ref()
-                                .map(|h| h.msg_id == msg_id).unwrap_or(false);
-                            if is_ours {
-                                match &msg.content {
-                                    JupyterMessageContent::ExecuteInput(input) => {
-                                        expected_ec = Some(input.execution_count.0 as i64);
-                                    }
-                                    JupyterMessageContent::Status(status) => {
-                                        if matches!(status.execution_state,
-                                            jupyter_protocol::ExecutionState::Idle) {
-                                            idle_received = true;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                    ydoc_result = ydoc.recv_update() => {
-                        ydoc_result.context("Y.js update error")?;
-                    }
-                }
-            }
+        if self.ydoc.is_some() {
+            self.execute_code_ydoc(code, cell_id, cell_index, on_output)
+                .await
+        } else {
+            self.execute_code_kernel_ws(code, cell_id, on_output).await
         }
-
-        let ec = ydoc
-            .read_cell_outputs(cell_idx)
-            .ok()
-            .and_then(|c| c.execution_count);
-        Ok(ExecutionResult::success(outputs, ec))
     }
 
     async fn stop(&mut self) -> Result<()> {

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -573,6 +573,14 @@ mod kernel_output_collector_tests {
         })
     }
 
+    fn display_data(plain_text: &str) -> JupyterMessageContent {
+        JupyterMessageContent::DisplayData(jupyter_protocol::DisplayData {
+            data: serde_json::from_value(serde_json::json!({ "text/plain": plain_text })).unwrap(),
+            metadata: serde_json::Map::new(),
+            transient: None,
+        })
+    }
+
     fn error(ename: &str, evalue: &str) -> JupyterMessageContent {
         JupyterMessageContent::ErrorOutput(jupyter_protocol::ErrorOutput {
             ename: ename.to_string(),
@@ -584,6 +592,7 @@ mod kernel_output_collector_tests {
     /// Feed a message sequence and return the final result, asserting that
     /// only a trailing Idle completes the collection.
     fn collect(messages: Vec<JupyterMessageContent>) -> ExecutionResult {
+        assert!(!messages.is_empty(), "test sequence must not be empty");
         let mut collector = KernelOutputCollector::new();
         let last = messages.len() - 1;
         for (i, msg) in messages.into_iter().enumerate() {
@@ -741,5 +750,68 @@ mod kernel_output_collector_tests {
             stream_texts(&result),
             vec![("stdout".to_string(), "new1 new2".to_string())]
         );
+    }
+
+    #[test]
+    fn deferred_clear_flushed_by_each_output_kind() {
+        for flusher in [
+            execute_result(1, "42"),
+            display_data("img"),
+            error("E", "v"),
+        ] {
+            let result = collect(vec![
+                stream(Stdio::Stdout, "stale"),
+                clear(true),
+                flusher,
+                status(ExecutionState::Idle),
+            ]);
+            assert_eq!(result.outputs.len(), 1, "stale output should be dropped");
+            assert!(
+                !matches!(&result.outputs[0], nbformat::v4::Output::Stream { .. }),
+                "remaining output should be the flushing output, not the stale stream"
+            );
+        }
+    }
+
+    #[test]
+    fn display_data_becomes_nbformat_output() {
+        let result = collect(vec![display_data("chart"), status(ExecutionState::Idle)]);
+        assert!(matches!(
+            result.outputs.as_slice(),
+            [nbformat::v4::Output::DisplayData(_)]
+        ));
+    }
+
+    #[test]
+    fn on_output_callback_receives_each_chunk_even_when_coalesced() {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = Arc::clone(&seen);
+        let cb: crate::execution::OutputCallback = Box::new(move |o| {
+            let label = match o {
+                nbformat::v4::Output::Stream { text, .. } => format!("stream:{}", text.0),
+                nbformat::v4::Output::ExecuteResult(_) => "result".to_string(),
+                other => format!("{:?}", other),
+            };
+            seen_clone.lock().unwrap().push(label);
+        });
+
+        let mut collector = KernelOutputCollector::new();
+        for msg in [
+            stream(Stdio::Stdout, "a"),
+            stream(Stdio::Stdout, "b"),
+            execute_result(1, "42"),
+        ] {
+            assert!(!collector.handle(msg, Some(&cb)));
+        }
+        let result = collector.into_result();
+
+        // Callback sees every chunk as it arrives...
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec!["stream:a", "stream:b", "result"]
+        );
+        // ...while persisted outputs coalesce the stream chunks.
+        assert_eq!(result.outputs.len(), 2);
     }
 }

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -219,6 +219,9 @@ impl RemoteExecutor {
         let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
         let mut execution_count: Option<i64> = None;
         let mut error_info: Option<ExecutionError> = None;
+        // Set by clear_output(wait=True): defer the clear until the next
+        // output arrives, keeping current outputs if none follows.
+        let mut clear_pending = false;
 
         loop {
             let msg = match tokio::time::timeout_at(deadline, ws.recv_message()).await {
@@ -248,6 +251,10 @@ impl RemoteExecutor {
                     break;
                 }
                 JupyterMessageContent::StreamContent(stream) => {
+                    if clear_pending {
+                        outputs.clear();
+                        clear_pending = false;
+                    }
                     let name = match stream.name {
                         jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
                         jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
@@ -259,7 +266,7 @@ impl RemoteExecutor {
                         };
                         cb(&chunk);
                     }
-                    // Coalesce consecutive streams with same name (matches nbclient behavior)
+                    // Merge consecutive same-name stream outputs into one entry
                     let coalesced = if let Some(nbformat::v4::Output::Stream {
                         name: ref last_name,
                         text: ref mut last_text,
@@ -282,6 +289,10 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::ExecuteResult(result) => {
+                    if clear_pending {
+                        outputs.clear();
+                        clear_pending = false;
+                    }
                     execution_count = Some(result.execution_count.value() as i64);
                     let json = serde_json::json!({
                         "output_type": "execute_result",
@@ -297,6 +308,10 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::DisplayData(display) => {
+                    if clear_pending {
+                        outputs.clear();
+                        clear_pending = false;
+                    }
                     let json = serde_json::json!({
                         "output_type": "display_data",
                         "data": display.data,
@@ -310,6 +325,10 @@ impl RemoteExecutor {
                     }
                 }
                 JupyterMessageContent::ErrorOutput(error) => {
+                    if clear_pending {
+                        outputs.clear();
+                        clear_pending = false;
+                    }
                     error_info = Some(ExecutionError {
                         ename: error.ename.clone(),
                         evalue: error.evalue.clone(),
@@ -325,8 +344,12 @@ impl RemoteExecutor {
                     }
                     outputs.push(output);
                 }
-                JupyterMessageContent::ClearOutput(_) => {
-                    outputs.clear();
+                JupyterMessageContent::ClearOutput(clear) => {
+                    if clear.wait {
+                        clear_pending = true;
+                    } else {
+                        outputs.clear();
+                    }
                 }
                 JupyterMessageContent::ExecuteInput(input) => {
                     execution_count = Some(input.execution_count.0 as i64);

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -194,6 +194,10 @@ impl RemoteExecutor {
                             // A closed socket yields None on every recv; without
                             // this arm the select busy-spins until the deadline
                             // and misreports the drop as a timeout.
+                            // No dedicated test: stubbing this path needs a full
+                            // y-sync handshake. The kernel-WS sibling pins the
+                            // equivalent behavior in
+                            // execute_errors_when_connection_drops_before_idle.
                             None => anyhow::bail!(
                                 "Kernel WebSocket closed before execution completed"
                             ),

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -162,6 +162,12 @@ impl RemoteExecutor {
                 }
             } else {
                 tokio::select! {
+                    _ = tokio::time::sleep_until(deadline) => {
+                        anyhow::bail!(
+                            "Cell execution timed out after {:?}",
+                            self.config.timeout
+                        );
+                    }
                     kernel_msg = ws.recv_message() => {
                         if let Some(msg) = kernel_msg? {
                             let is_ours = msg.parent_header.as_ref()

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -830,3 +830,69 @@ mod kernel_output_collector_tests {
         assert_eq!(result.outputs.len(), 2);
     }
 }
+
+#[cfg(test)]
+mod kernel_ws_execute_tests {
+    use super::*;
+
+    /// A server that completes the v1-subprotocol handshake and then goes
+    /// silent must trip the per-cell deadline, not hang.
+    #[tokio::test]
+    async fn execute_times_out_when_kernel_never_responds() {
+        use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let _ws = tokio_tungstenite::accept_hdr_async(
+                    stream,
+                    |_req: &Request, mut resp: Response| {
+                        resp.headers_mut().insert(
+                            "Sec-WebSocket-Protocol",
+                            "v1.kernel.websocket.jupyter.org".parse().unwrap(),
+                        );
+                        Ok(resp)
+                    },
+                )
+                .await;
+                // Hold the connection open without ever sending a message
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            }
+        });
+
+        let ws = KernelWebSocket::connect(&format!("ws://{}/api/kernels/k/channels", addr))
+            .await
+            .unwrap();
+
+        let mut executor = RemoteExecutor {
+            config: ExecutionConfig {
+                timeout: std::time::Duration::from_millis(300),
+                ..Default::default()
+            },
+            server_url: format!("http://{}", addr),
+            token: "t".to_string(),
+            client: None,
+            session: None,
+            ws: Some(ws),
+            ydoc: None,
+            created_session: false,
+        };
+
+        let started = tokio::time::Instant::now();
+        let err = match executor.execute_code_kernel_ws("1 + 1", None, None).await {
+            Ok(_) => panic!("execution must time out when the kernel never responds"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("timed out"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "timeout must fire promptly, took {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -158,6 +158,9 @@ impl RemoteExecutor {
                 match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => return Err(e).context("Y.js update error"),
+                    // Kernel already reported idle, so execution finished;
+                    // only output sync timed out. Return what we collected
+                    // instead of erroring (unlike the pre-idle timeout below).
                     Err(_) => break,
                 }
             } else {

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -204,6 +204,7 @@ impl RemoteExecutor {
         on_output: Option<&crate::execution::OutputCallback>,
     ) -> Result<ExecutionResult> {
         let ws = self.ws.as_mut().context("WebSocket not connected")?;
+        let deadline = tokio::time::Instant::now() + self.config.timeout;
 
         let msg_id = ws
             .send_execute_request(code, !self.config.allow_errors, cell_id)
@@ -214,9 +215,11 @@ impl RemoteExecutor {
         let mut error_info: Option<ExecutionError> = None;
 
         loop {
-            let msg = match ws.recv_message().await? {
-                Some(msg) => msg,
-                None => break,
+            let msg = match tokio::time::timeout_at(deadline, ws.recv_message()).await {
+                Ok(Ok(Some(msg))) => msg,
+                Ok(Ok(None)) => break,
+                Ok(Err(e)) => return Err(e).context("WebSocket error"),
+                Err(_) => anyhow::bail!("Cell execution timed out after {:?}", self.config.timeout),
             };
 
             let is_ours = msg

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -194,10 +194,6 @@ impl RemoteExecutor {
                             // A closed socket yields None on every recv; without
                             // this arm the select busy-spins until the deadline
                             // and misreports the drop as a timeout.
-                            // No dedicated test: stubbing this path needs a full
-                            // y-sync handshake. The kernel-WS sibling pins the
-                            // equivalent behavior in
-                            // execute_errors_when_connection_drops_before_idle.
                             None => anyhow::bail!(
                                 "Kernel WebSocket closed before execution completed"
                             ),

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -224,7 +224,12 @@ impl RemoteExecutor {
         loop {
             let msg = match tokio::time::timeout_at(deadline, ws.recv_message()).await {
                 Ok(Ok(Some(msg))) => msg,
-                Ok(Ok(None)) => break,
+                // A closed socket before idle means we cannot know whether the
+                // cell completed; reporting success with empty outputs would
+                // make a dropped connection look like a no-output cell.
+                Ok(Ok(None)) => {
+                    anyhow::bail!("Kernel WebSocket closed before execution completed")
+                }
                 Ok(Err(e)) => return Err(e).context("WebSocket error"),
                 Err(_) => anyhow::bail!("Cell execution timed out after {:?}", self.config.timeout),
             };
@@ -893,6 +898,66 @@ mod kernel_ws_execute_tests {
             started.elapsed() < std::time::Duration::from_secs(5),
             "timeout must fire promptly, took {:?}",
             started.elapsed()
+        );
+    }
+
+    /// A connection dropped before idle must surface as an error, not as a
+    /// successful execution with empty outputs.
+    #[tokio::test]
+    async fn execute_errors_when_connection_drops_before_idle() {
+        use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let ws = tokio_tungstenite::accept_hdr_async(
+                    stream,
+                    |_req: &Request, mut resp: Response| {
+                        resp.headers_mut().insert(
+                            "Sec-WebSocket-Protocol",
+                            "v1.kernel.websocket.jupyter.org".parse().unwrap(),
+                        );
+                        Ok(resp)
+                    },
+                )
+                .await;
+                drop(ws);
+            }
+        });
+
+        let ws = KernelWebSocket::connect(&format!("ws://{}/api/kernels/k/channels", addr))
+            .await
+            .unwrap();
+
+        let mut executor = RemoteExecutor {
+            config: ExecutionConfig {
+                timeout: std::time::Duration::from_secs(10),
+                ..Default::default()
+            },
+            server_url: format!("http://{}", addr),
+            token: "t".to_string(),
+            client: None,
+            session: None,
+            ws: Some(ws),
+            ydoc: None,
+            created_session: false,
+        };
+
+        let err = match executor.execute_code_kernel_ws("1 + 1", None, None).await {
+            Ok(r) => panic!(
+                "dropped connection must not report success (got success={}, outputs={})",
+                r.success,
+                r.outputs.len()
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("closed before execution completed")
+                || err.to_string().contains("WebSocket error"),
+            "unexpected error: {}",
+            err
         );
     }
 }

--- a/src/execution/remote/mod.rs
+++ b/src/execution/remote/mod.rs
@@ -246,14 +246,34 @@ impl RemoteExecutor {
                         jupyter_protocol::Stdio::Stdout => "stdout".to_string(),
                         jupyter_protocol::Stdio::Stderr => "stderr".to_string(),
                     };
-                    let output = nbformat::v4::Output::Stream {
-                        name,
-                        text: nbformat::v4::MultilineString(stream.text),
-                    };
                     if let Some(cb) = &on_output {
-                        cb(&output);
+                        let chunk = nbformat::v4::Output::Stream {
+                            name: name.clone(),
+                            text: nbformat::v4::MultilineString(stream.text.clone()),
+                        };
+                        cb(&chunk);
                     }
-                    outputs.push(output);
+                    // Coalesce consecutive streams with same name (matches nbclient behavior)
+                    let coalesced = if let Some(nbformat::v4::Output::Stream {
+                        name: ref last_name,
+                        text: ref mut last_text,
+                    }) = outputs.last_mut()
+                    {
+                        if *last_name == name {
+                            last_text.0.push_str(&stream.text);
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+                    if !coalesced {
+                        outputs.push(nbformat::v4::Output::Stream {
+                            name,
+                            text: nbformat::v4::MultilineString(stream.text),
+                        });
+                    }
                 }
                 JupyterMessageContent::ExecuteResult(result) => {
                     execution_count = Some(result.execution_count.value() as i64);
@@ -298,6 +318,9 @@ impl RemoteExecutor {
                         cb(&output);
                     }
                     outputs.push(output);
+                }
+                JupyterMessageContent::ClearOutput(_) => {
+                    outputs.clear();
                 }
                 JupyterMessageContent::ExecuteInput(input) => {
                     execution_count = Some(input.execution_count.0 as i64);

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -79,7 +79,7 @@ impl KernelWebSocket {
                 .context("Invalid Sec-WebSocket-Protocol value")?,
         );
 
-        let (ws_stream, _) = connect_async(req)
+        let (ws_stream, _) = tokio_tungstenite::connect_async(req)
             .await
             .context("Failed to connect to kernel WebSocket")?;
 

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -34,9 +34,21 @@ impl KernelWebSocket {
             SEC_WEBSOCKET_PROTOCOL,
             HeaderValue::from_static("v1.kernel.websocket.jupyter.org"),
         );
-        let (ws_stream, _) = tokio_tungstenite::connect_async(request)
+        let (ws_stream, response) = tokio_tungstenite::connect_async(request)
             .await
             .context("Failed to connect to kernel WebSocket")?;
+
+        let accepted = response
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if accepted != "v1.kernel.websocket.jupyter.org" {
+            anyhow::bail!(
+                "Server does not support WebSocket v1 kernel protocol (got {:?})",
+                accepted
+            );
+        }
 
         let (write, read) = ws_stream.split();
 

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -333,6 +333,9 @@ mod tests {
     async fn connect_rejects_server_without_v1_subprotocol() {
         // accept_async completes the WebSocket handshake without echoing any
         // subprotocol, which is how a legacy/incompatible server responds.
+        // Note: tungstenite 0.23+ rejects missing subprotocols client-side with
+        // SubProtocolError; on a dependency bump this assertion's message check
+        // needs updating, but the rejection itself remains.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -324,3 +324,34 @@ impl KernelWebSocket {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_rejects_server_without_v1_subprotocol() {
+        // accept_async completes the WebSocket handshake without echoing any
+        // subprotocol, which is how a legacy/incompatible server responds.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let _ws = tokio_tungstenite::accept_async(stream).await;
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
+        });
+
+        let err = match KernelWebSocket::connect(&format!("ws://{}/api/kernels/k/channels", addr))
+            .await
+        {
+            Ok(_) => panic!("connect must fail when the server does not accept the v1 subprotocol"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("WebSocket v1 kernel protocol"),
+            "unexpected error: {}",
+            err
+        );
+    }
+}

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -79,9 +79,21 @@ impl KernelWebSocket {
                 .context("Invalid Sec-WebSocket-Protocol value")?,
         );
 
-        let (ws_stream, _) = tokio_tungstenite::connect_async(req)
+        let (ws_stream, response) = tokio_tungstenite::connect_async(req)
             .await
             .context("Failed to connect to kernel WebSocket")?;
+
+        let accepted = response
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if accepted != "v1.kernel.websocket.jupyter.org" {
+            anyhow::bail!(
+                "Server does not support WebSocket v1 kernel protocol (got {:?})",
+                accepted
+            );
+        }
 
         let (write, read) = ws_stream.split();
         Ok(Self { write, read })
@@ -328,6 +340,35 @@ impl KernelWebSocket {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn connect_with_auth_rejects_server_without_v1_subprotocol() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let _ws = tokio_tungstenite::accept_async(stream).await;
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
+        });
+
+        let err = match KernelWebSocket::connect_with_auth(
+            &format!("ws://{}/api/kernels/k/channels", addr),
+            "token test",
+        )
+        .await
+        {
+            Ok(_) => panic!(
+                "connect_with_auth must fail when the server does not accept the v1 subprotocol"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("WebSocket v1 kernel protocol"),
+            "unexpected error: {}",
+            err
+        );
+    }
 
     #[tokio::test]
     async fn connect_rejects_server_without_v1_subprotocol() {

--- a/src/execution/remote/websocket.rs
+++ b/src/execution/remote/websocket.rs
@@ -3,7 +3,11 @@
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
 use jupyter_protocol::messaging::{JupyterMessage, JupyterMessageContent};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::tungstenite::{
+    client::IntoClientRequest,
+    http::header::{HeaderValue, SEC_WEBSOCKET_PROTOCOL},
+    Message,
+};
 
 /// WebSocket connection to a Jupyter kernel
 pub struct KernelWebSocket {
@@ -23,7 +27,14 @@ pub struct KernelWebSocket {
 impl KernelWebSocket {
     /// Connect to a kernel via WebSocket
     pub async fn connect(ws_url: &str) -> Result<Self> {
-        let (ws_stream, _) = connect_async(ws_url)
+        let mut request = ws_url
+            .into_client_request()
+            .context("Invalid WebSocket URL")?;
+        request.headers_mut().insert(
+            SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("v1.kernel.websocket.jupyter.org"),
+        );
+        let (ws_stream, _) = tokio_tungstenite::connect_async(request)
             .await
             .context("Failed to connect to kernel WebSocket")?;
 

--- a/src/execution/remote/ydoc.rs
+++ b/src/execution/remote/ydoc.rs
@@ -50,10 +50,29 @@ struct FileIdResponse {
     id: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct CollabSessionResponse {
-    #[serde(rename = "fileId")]
-    file_id: String,
+/// Definitive signal that the server has no compatible Y.js backend: the
+/// FileID index endpoint (registered only by jupyter-server-documents) is
+/// absent. Callers route to the Contents API path on this error; any other
+/// failure (network, 5xx) is transient and must surface as a real error so a
+/// flaky collaboration server is never silently downgraded.
+#[derive(Debug)]
+pub struct YjsUnavailable;
+
+impl std::fmt::Display for YjsUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "server has no Y.js collaboration backend (FileID index endpoint not found)"
+        )
+    }
+}
+
+impl std::error::Error for YjsUnavailable {}
+
+/// True when the error chain contains the definitive backend-absent marker.
+pub fn is_yjs_unavailable(e: &anyhow::Error) -> bool {
+    e.chain()
+        .any(|c| c.downcast_ref::<YjsUnavailable>().is_some())
 }
 
 /// Y.js document client for syncing notebook changes with Jupyter Server
@@ -100,12 +119,15 @@ impl YDocClient {
         }
     }
 
-    /// Get unique file ID for notebook path via FileID API.
-    /// Tries jupyter-server-documents first, falls back to jupyter-collaboration session endpoint.
+    /// Get unique file ID for notebook path via POST /api/fileid/index
+    /// (registered only by jupyter-server-documents, create-if-not-exists).
+    /// A 404 means the backend is absent and returns [`YjsUnavailable`] so
+    /// callers can fall back to the Contents API path. jupyter-collaboration
+    /// is intentionally not detected here: its room protocol is not compatible
+    /// with this client (see #95 for full support).
     async fn get_file_id(server_url: &str, token: &str, notebook_path: &str) -> Result<String> {
         let http_client = HttpClient::new();
 
-        // Try jupyter-server-documents: POST /api/fileid/index (create-if-not-exists)
         let index_url = format!("{}/api/fileid/index", server_url);
         let response = http_client
             .post(&index_url)
@@ -133,49 +155,14 @@ impl YDocClient {
             return Ok(file_id_response.id);
         }
 
-        if response.status().as_u16() != 404 {
-            let status = response.status();
-            let error_text = response.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "FileID API request failed with status {}: {}",
-                status,
-                error_text
-            );
-        }
-
-        // Fallback: try jupyter-collaboration session endpoint (indexes the file if needed)
-        let mut session_url = Url::parse(server_url).context("Invalid server URL")?;
-        session_url.set_path(&format!("/api/collaboration/session/{}", notebook_path));
-        let response = http_client
-            .put(session_url)
-            .header("Authorization", format!("token {}", token))
-            .header("Content-Type", "application/json")
-            .body(r#"{"format":"json","type":"notebook"}"#)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to call collaboration session API: {}", e))?;
-
-        if response.status().is_success() {
-            let session_response: CollabSessionResponse = response
-                .json()
-                .await
-                .context("Failed to parse collaboration session response")?;
-            return Ok(session_response.file_id);
+        if response.status().as_u16() == 404 {
+            return Err(anyhow::Error::new(YjsUnavailable));
         }
 
         let status = response.status();
         let error_text = response.text().await.unwrap_or_default();
-        if status.as_u16() == 404 {
-            anyhow::bail!(
-                "FileID API request failed with status {}: {}. \
-                 Make sure jupyter-server-documents or jupyter-collaboration is installed: \
-                 pip install jupyter-server-documents (or pip install jupyter-collaboration)",
-                status,
-                error_text
-            );
-        }
         anyhow::bail!(
-            "Collaboration session API request failed with status {}: {}",
+            "FileID API request failed with status {}: {}",
             status,
             error_text
         );
@@ -570,5 +557,91 @@ impl YDocClient {
             .await
             .context("Failed to close WebSocket")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod fileid_classification_tests {
+    use super::{is_yjs_unavailable, YDocClient, YjsUnavailable};
+    use anyhow::{anyhow, Context};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Minimal stub for POST /api/fileid/index: drains the request and replies
+    /// with the given status. For 200 it returns a valid FileID body.
+    async fn fileid_stub(status: u16) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut tmp = [0u8; 1024];
+                let _ = sock.read(&mut tmp).await;
+                let body = if status == 200 {
+                    r#"{"id":"file-123","path":"n.ipynb"}"#
+                } else {
+                    "{}"
+                };
+                let resp = format!(
+                    "HTTP/1.1 {} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status,
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn get_file_id_returns_id_on_success() {
+        let url = fileid_stub(200).await;
+        let id = YDocClient::get_file_id(&url, "t", "n.ipynb").await.unwrap();
+        assert_eq!(id, "file-123");
+    }
+
+    #[tokio::test]
+    async fn get_file_id_signals_yjs_unavailable_on_404() {
+        let url = fileid_stub(404).await;
+        let err = YDocClient::get_file_id(&url, "t", "n.ipynb")
+            .await
+            .unwrap_err();
+        assert!(
+            is_yjs_unavailable(&err),
+            "404 must classify as YjsUnavailable, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn get_file_id_is_hard_error_on_500() {
+        // A transient server error must NOT be treated as backend-absent,
+        // otherwise a flaky collaboration server would be silently downgraded.
+        let url = fileid_stub(500).await;
+        let err = YDocClient::get_file_id(&url, "t", "n.ipynb")
+            .await
+            .unwrap_err();
+        assert!(
+            !is_yjs_unavailable(&err),
+            "500 must be a hard error, not YjsUnavailable, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn is_yjs_unavailable_finds_marker_directly_and_through_context() {
+        let direct = anyhow!(YjsUnavailable);
+        assert!(is_yjs_unavailable(&direct));
+
+        let wrapped = Err::<(), _>(anyhow!(YjsUnavailable))
+            .context("Error adding cells")
+            .unwrap_err();
+        assert!(
+            is_yjs_unavailable(&wrapped),
+            "marker must be found through a context() layer"
+        );
+
+        let unrelated = anyhow!("connection refused");
+        assert!(!is_yjs_unavailable(&unrelated));
     }
 }

--- a/src/execution/remote/ydoc.rs
+++ b/src/execution/remote/ydoc.rs
@@ -50,11 +50,18 @@ struct FileIdResponse {
     id: String,
 }
 
-/// Definitive signal that the server has no compatible Y.js backend: the
-/// FileID index endpoint (registered only by jupyter-server-documents) is
-/// absent. Callers route to the Contents API path on this error; any other
-/// failure (network, 5xx) is transient and must surface as a real error so a
-/// flaky collaboration server is never silently downgraded.
+#[derive(Debug, Deserialize)]
+struct CollabSessionResponse {
+    #[serde(rename = "fileId")]
+    file_id: String,
+}
+
+/// Definitive signal that the server has no compatible Y.js backend: neither
+/// the FileID index endpoint (jupyter-server-documents) nor the collaboration
+/// session endpoint (jupyter-collaboration) is present. Callers route to the
+/// Contents API path on this error; any other failure (network, 5xx) is
+/// transient and must surface as a real error so a flaky collaboration server
+/// is never silently downgraded.
 #[derive(Debug)]
 pub struct YjsUnavailable;
 
@@ -119,12 +126,15 @@ impl YDocClient {
         }
     }
 
-    /// Get unique file ID for notebook path via POST /api/fileid/index
-    /// (registered only by jupyter-server-documents, create-if-not-exists).
-    /// A 404 means the backend is absent and returns [`YjsUnavailable`] so
-    /// callers can fall back to the Contents API path. jupyter-collaboration
-    /// is intentionally not detected here: its room protocol is not compatible
-    /// with this client (see #95 for full support).
+    /// Resolve the Y.js file ID for a notebook, trying both backends.
+    ///
+    /// First POST /api/fileid/index (registered only by jupyter-server-documents,
+    /// create-if-not-exists). On a 404 there, fall back to
+    /// /api/collaboration/session (jupyter-collaboration). If both are absent
+    /// (404), return [`YjsUnavailable`] so callers fall back to the Contents API
+    /// path. A non-404 from either endpoint is transient and stays a hard error,
+    /// so a flaky collaboration server is never silently downgraded. (#95 extends
+    /// the collaboration-session branch for full jupyter-collaboration support.)
     async fn get_file_id(server_url: &str, token: &str, notebook_path: &str) -> Result<String> {
         let http_client = HttpClient::new();
 
@@ -155,6 +165,41 @@ impl YDocClient {
             return Ok(file_id_response.id);
         }
 
+        if response.status().as_u16() != 404 {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "FileID API request failed with status {}: {}",
+                status,
+                error_text
+            );
+        }
+
+        // jupyter-server-documents is absent. Fall back to the
+        // jupyter-collaboration session endpoint, which indexes the file if
+        // needed and returns its fileId.
+        let mut session_url = Url::parse(server_url).context("Invalid server URL")?;
+        session_url.set_path(&format!("/api/collaboration/session/{}", notebook_path));
+        let response = http_client
+            .put(session_url)
+            .header("Authorization", format!("token {}", token))
+            .header("Content-Type", "application/json")
+            .body(r#"{"format":"json","type":"notebook"}"#)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to call collaboration session API: {}", e))?;
+
+        if response.status().is_success() {
+            let session_response: CollabSessionResponse = response
+                .json()
+                .await
+                .context("Failed to parse collaboration session response")?;
+            return Ok(session_response.file_id);
+        }
+
+        // Neither backend answered. A 404 is the definitive backend-absent
+        // signal: return YjsUnavailable so callers use the Contents API. Any
+        // other status is transient and stays a hard error.
         if response.status().as_u16() == 404 {
             return Err(anyhow::Error::new(YjsUnavailable));
         }
@@ -162,7 +207,7 @@ impl YDocClient {
         let status = response.status();
         let error_text = response.text().await.unwrap_or_default();
         anyhow::bail!(
-            "FileID API request failed with status {}: {}",
+            "Collaboration session API request failed with status {}: {}",
             status,
             error_text
         );
@@ -566,13 +611,16 @@ mod fileid_classification_tests {
     use anyhow::{anyhow, Context};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    /// Minimal stub for POST /api/fileid/index: drains the request and replies
-    /// with the given status. For 200 it returns a valid FileID body.
+    /// Minimal stub that replies to every request with the given status.
+    /// get_file_id may hit two endpoints (fileid/index, then
+    /// collaboration/session), each a fresh connection, so the stub serves
+    /// repeated connections rather than a single one. For 200 it returns a
+    /// valid FileID body.
     async fn fileid_stub(status: u16) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
-            if let Ok((mut sock, _)) = listener.accept().await {
+            while let Ok((mut sock, _)) = listener.accept().await {
                 let mut tmp = [0u8; 1024];
                 let _ = sock.read(&mut tmp).await;
                 let body = if status == 200 {
@@ -602,6 +650,8 @@ mod fileid_classification_tests {
 
     #[tokio::test]
     async fn get_file_id_signals_yjs_unavailable_on_404() {
+        // Both fileid/index and the collaboration/session fallback 404 (vanilla
+        // server), so the terminal classification must be YjsUnavailable.
         let url = fileid_stub(404).await;
         let err = YDocClient::get_file_id(&url, "t", "n.ipynb")
             .await

--- a/src/execution/remote/ydoc.rs
+++ b/src/execution/remote/ydoc.rs
@@ -50,6 +50,12 @@ struct FileIdResponse {
     id: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct CollabSessionResponse {
+    #[serde(rename = "fileId")]
+    file_id: String,
+}
+
 /// Y.js document client for syncing notebook changes with Jupyter Server
 pub struct YDocClient {
     doc: Doc,
@@ -94,13 +100,15 @@ impl YDocClient {
         }
     }
 
-    /// Get unique file ID for notebook path via FileID API
+    /// Get unique file ID for notebook path via FileID API.
+    /// Tries jupyter-server-documents first, falls back to jupyter-collaboration session endpoint.
     async fn get_file_id(server_url: &str, token: &str, notebook_path: &str) -> Result<String> {
-        let url = format!("{}/api/fileid/index", server_url);
-
         let http_client = HttpClient::new();
+
+        // Try jupyter-server-documents: POST /api/fileid/index (create-if-not-exists)
+        let index_url = format!("{}/api/fileid/index", server_url);
         let response = http_client
-            .post(&url)
+            .post(&index_url)
             .query(&[("path", notebook_path)])
             .header("Authorization", format!("token {}", token))
             .send()
@@ -117,24 +125,60 @@ impl YDocClient {
                 }
             })?;
 
-        if !response.status().is_success() {
+        if response.status().is_success() {
+            let file_id_response: FileIdResponse = response
+                .json()
+                .await
+                .context("Failed to parse FileID API response")?;
+            return Ok(file_id_response.id);
+        }
+
+        if response.status().as_u16() != 404 {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
             anyhow::bail!(
-                "FileID API request failed with status {}: {}. \
-                 Make sure jupyter-server-documents is installed: \
-                 pip install jupyter-server-documents",
+                "FileID API request failed with status {}: {}",
                 status,
                 error_text
             );
         }
 
-        let file_id_response: FileIdResponse = response
-            .json()
+        // Fallback: try jupyter-collaboration session endpoint (indexes the file if needed)
+        let mut session_url = Url::parse(server_url).context("Invalid server URL")?;
+        session_url.set_path(&format!("/api/collaboration/session/{}", notebook_path));
+        let response = http_client
+            .put(session_url)
+            .header("Authorization", format!("token {}", token))
+            .header("Content-Type", "application/json")
+            .body(r#"{"format":"json","type":"notebook"}"#)
+            .send()
             .await
-            .context("Failed to parse FileID API response")?;
+            .map_err(|e| anyhow::anyhow!("Failed to call collaboration session API: {}", e))?;
 
-        Ok(file_id_response.id)
+        if response.status().is_success() {
+            let session_response: CollabSessionResponse = response
+                .json()
+                .await
+                .context("Failed to parse collaboration session response")?;
+            return Ok(session_response.file_id);
+        }
+
+        let status = response.status();
+        let error_text = response.text().await.unwrap_or_default();
+        if status.as_u16() == 404 {
+            anyhow::bail!(
+                "FileID API request failed with status {}: {}. \
+                 Make sure jupyter-server-documents or jupyter-collaboration is installed: \
+                 pip install jupyter-server-documents (or pip install jupyter-collaboration)",
+                status,
+                error_text
+            );
+        }
+        anyhow::bail!(
+            "Collaboration session API request failed with status {}: {}",
+            status,
+            error_text
+        );
     }
 
     /// Build WebSocket URL for Y.js room

--- a/src/execution/types.rs
+++ b/src/execution/types.rs
@@ -44,6 +44,9 @@ pub struct ExecutionConfig {
 
     /// Restart kernel before execution (remote mode only; applies to any cell range)
     pub restart_kernel: bool,
+
+    /// Whether Y.js backend is available (None = unknown, try and fall back)
+    pub ydoc_available: Option<bool>,
 }
 
 impl Default for ExecutionConfig {
@@ -56,6 +59,7 @@ impl Default for ExecutionConfig {
             notebook_path: None,
             env_config: None,
             restart_kernel: false,
+            ydoc_available: None,
         }
     }
 }

--- a/src/execution/types.rs
+++ b/src/execution/types.rs
@@ -151,14 +151,12 @@ impl MessageOutput {
     /// Convert to nbformat Output
     #[allow(dead_code)]
     pub fn to_nbformat_output(&self) -> Result<nbformat::v4::Output> {
-        // Use serde to convert between the types
         match self {
             MessageOutput::Stream { name, text } => Ok(nbformat::v4::Output::Stream {
                 name: name.clone(),
                 text: nbformat::v4::MultilineString(text.clone()),
             }),
             MessageOutput::DisplayData { data, metadata } => {
-                // Create a temporary JSON object with the right structure
                 let json = serde_json::json!({
                     "output_type": "display_data",
                     "data": data,
@@ -171,7 +169,6 @@ impl MessageOutput {
                 metadata,
                 execution_count,
             } => {
-                // Create a temporary JSON object with the right structure
                 let json = serde_json::json!({
                     "output_type": "execute_result",
                     "execution_count": execution_count,
@@ -192,3 +189,4 @@ impl MessageOutput {
         }
     }
 }
+

--- a/src/execution/types.rs
+++ b/src/execution/types.rs
@@ -189,4 +189,3 @@ impl MessageOutput {
         }
     }
 }
-


### PR DESCRIPTION
Fixes #93

## Problem

Connect mode requires Y.js infrastructure (FileID API, collaboration room WebSocket) for every remote operation and fails against vanilla `jupyter_server` with no collaboration packages installed (as seen in CI failures in #91). Vanilla jupyter_server provides everything needed: the kernel WebSocket already delivers all execution outputs (the remote executor currently discards them), and the Contents API reads and writes notebooks.

## Changes

- `nb connect` probes `POST /api/fileid/index`, stores `ydoc_available` in `.jupyter/cli.json`, prints `Mode: direct` or `Mode: collaborative`. `GET /api/fileid/id` cannot be used as the probe: it 404s for unindexed paths even when the extension is installed, so fresh servers would always probe as vanilla. `POST /api/fileid/index` is registered by jupyter-server-documents only (verified against all three server types). Ad-hoc `--server`/`--token` probes per command, `--skip-validation` skips the probe.
- `execute_code_kernel_ws()` in `remote/mod.rs` collects outputs from kernel WS messages (stream, execute_result, display_data, error, clear_output), same set as the local executor. Coalesces consecutive same-name streams and defers `clear_output(wait=True)` until the next output, matching nbclient. Every recv is bounded by the per-cell deadline.
- `websocket.rs` negotiates the `v1.kernel.websocket.jupyter.org` subprotocol and fails fast if not accepted, since the client only speaks v1 binary framing.
- `execute` saves the notebook with outputs via `PUT /api/contents/{path}` when no Y.js backend is present. The notebook is read from the server first, so the write-back is a consistent read-modify-save.
- `cell add`/`update`/`delete` and `output clear` share a `with_contents_api()` read-modify-save helper in `common.rs`. Results print only after the save succeeds.
- The pre-idle `tokio::select!` in the Y.js output loop gained a deadline arm; previously a missed `Status(Idle)` blocked forever. Same defect #89 fixes, deduplicate on rebase.
- jupyter-collaboration probes as direct and works through the Contents API path. Full Y.js support for it is #95.

## Testing

End-to-end against real servers in clean venvs.

| Scenario | vanilla 2.19.0 | jupyter-server-documents 0.2.2 | jupyter-collaboration 4.4.1 |
|---|---|---|---|
| `nb connect` mode detected | direct | collaborative | direct |
| add / update / delete / output clear | OK (Contents API) | OK (Y.js) | OK (Contents API) |
| `execute`, error capture, stream coalescing | OK | OK | OK |
| single-cell re-exec keeps kernel state | OK | OK | OK |
| ad-hoc `--server`/`--token`, `--skip-validation` | OK | OK | OK |

jupyter-server-documents must be tested with a fresh `JUPYTER_DATA_DIR`: the fileid database is user-global and a stale probe record masks detection bugs.

## Merge order

No hard ordering, second to merge rebases:

- [ ] #89 adds the same Y.js select deadline arm, deduplicate on rebase
- [ ] After #95, extend the probe to treat `PUT /api/collaboration/session/{path}` success as Y.js-capable so jupyter-collaboration routes to the realtime path
