### PR TITLE
Fix connect-mode fixture: decouple cell-set source from expected output

### DIFF
--- a/tests/fixtures/for_connect_restart.ipynb
+++ b/tests/fixtures/for_connect_restart.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "persistent_var = 999"
+    "persistent_var = 3 * 333"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Test notebook cell source `persistent_var = 999` was identical to the assert statement `result.stdout.contains("persistent_var = 999")` in the integration tests for connect mode. This could produce false success runs even if the run outputs did not produce anything or they failed.

  Changed cell code to `persistent_var = 3 * 333` (still evaluates to 999 at runtime, but the source text no longer
  matches the expected output string). The assertion is now only satisfiable by real print output. Confirmed
  against both jsd and jupyter-collaboration backends - all 6 non-ignored tests pass; an intermediate bad value
  (33 * 3 = 99) correctly failed the assertion.