### PR TITLE
Add sanity tests for larger notebooks (local + connect mode)

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,6 +44,14 @@ test-all:
 test-connect backend="jsd":
     NB_TEST_BACKEND={{backend}} cargo test --test integration_connect_mode -- --test-threads=1
 
+# Run sanity tests for larger notebooks (local execution, no server required).
+test-sanity:
+    cargo test --test integration_sanity_large -- --test-threads=1
+
+# Run connect-mode sanity tests. Usage: just test-sanity-connect jsd
+test-sanity-connect backend="none":
+    NB_TEST_BACKEND={{backend}} cargo test --test integration_sanity_large_connect -- --test-threads=1
+
 # Format code
 fmt:
     cargo fmt

--- a/tests/fixtures/large_heavy_output.ipynb
+++ b/tests/fixtures/large_heavy_output.ipynb
@@ -1,0 +1,93 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(100):\n",
+    "    print(f\"output_line_{i:04d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "data = [{\"id\": i, \"value\": i**2, \"label\": f\"item_{i}\"} for i in range(50)]\n",
+    "print(json.dumps(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header = \"| {:>5} | {:>10} | {:>15} |\".format(\"ID\", \"Value\", \"Squared\")\n",
+    "sep = \"|\" + \"-\"*7 + \"|\" + \"-\"*12 + \"|\" + \"-\"*17 + \"|\"\n",
+    "print(header)\n",
+    "print(sep)\n",
+    "for i in range(30):\n",
+    "    print(\"| {:>5} | {:>10} | {:>15} |\".format(i, i*3, i**2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matrix = []\n",
+    "for i in range(10):\n",
+    "    row = []\n",
+    "    for j in range(10):\n",
+    "        row.append(i * j)\n",
+    "    matrix.append(row)\n",
+    "    print(f\"row_{i}: {row}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "words = [\"alpha\", \"beta\", \"gamma\", \"delta\", \"epsilon\"]\n",
+    "result = []\n",
+    "for i in range(20):\n",
+    "    w = words[i % len(words)]\n",
+    "    result.append(f\"{w}_{i:03d}\")\n",
+    "print(\" \".join(result))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"total_output_lines=100\")\n",
+    "print(f\"data_items={len(data)}\")\n",
+    "print(f\"matrix_rows={len(matrix)}\")\n",
+    "print(\"HEAVY_OUTPUT_COMPLETE\")"
+   ]
+  }
+ ]
+}

--- a/tests/fixtures/large_stateful.ipynb
+++ b/tests/fixtures/large_stateful.ipynb
@@ -1,0 +1,237 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "import math\n",
+    "import json\n",
+    "print(f\"Python {sys.version_info.major}.{sys.version_info.minor}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Large Notebook Sanity Test\n",
+    "\n",
+    "This notebook exercises execution across many cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = list(range(100))\n",
+    "total = sum(data)\n",
+    "print(f\"total={total}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 1: Computation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = []\n",
+    "for i in range(5):\n",
+    "    val = math.sqrt(i * 100)\n",
+    "    results.append(val)\n",
+    "    print(f\"sqrt({i*100})={val:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapping = {f\"key_{i}\": i**2 for i in range(10)}\n",
+    "print(f\"keys={len(mapping)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"hello world \" * 50\n",
+    "words = text.split()\n",
+    "print(f\"word_count={len(words)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 2: State Propagation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined = total + len(mapping) + len(words)\n",
+    "print(f\"combined={combined}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nested = {\"data\": data[:5], \"results\": results, \"mapping_subset\": {k: v for k, v in list(mapping.items())[:3]}}\n",
+    "print(json.dumps(nested, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Counter:\n",
+    "    def __init__(self, start=0):\n",
+    "        self.value = start\n",
+    "    def increment(self, by=1):\n",
+    "        self.value += by\n",
+    "        return self.value\n",
+    "    def __repr__(self):\n",
+    "        return f\"Counter({self.value})\"\n",
+    "\n",
+    "c = Counter(10)\n",
+    "print(c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for _ in range(5):\n",
+    "    c.increment(3)\n",
+    "print(f\"counter_final={c.value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 3: Multi-line Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(20):\n",
+    "    print(f\"line_{i:03d}: {'*' * (i+1)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    result = 100 / 4\n",
+    "    print(f\"safe_division={result}\")\n",
+    "except ZeroDivisionError:\n",
+    "    print(\"ERROR: division by zero\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = []\n",
+    "for row in range(5):\n",
+    "    cols = [f\"{row},{col}\" for col in range(4)]\n",
+    "    table.append(\" | \".join(cols))\n",
+    "for line in table:\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 4: Final Assertions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert total == 4950, f\"Expected 4950, got {total}\"\n",
+    "assert len(results) == 5\n",
+    "assert c.value == 25, f\"Expected 25, got {c.value}\"\n",
+    "assert combined == 5060\n",
+    "print(\"all_assertions_passed=True\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = {\n",
+    "    \"total\": total,\n",
+    "    \"results_count\": len(results),\n",
+    "    \"counter\": c.value,\n",
+    "    \"combined\": combined,\n",
+    "    \"word_count\": len(words),\n",
+    "}\n",
+    "print(f\"SUMMARY: {json.dumps(summary)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"NOTEBOOK_COMPLETE\")"
+   ]
+  }
+ ]
+}

--- a/tests/fixtures/large_with_error.ipynb
+++ b/tests/fixtures/large_with_error.ipynb
@@ -1,0 +1,65 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 10\n",
+    "print(f\"setup_done x={x}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = x * 2\n",
+    "print(f\"y={y}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell raises an error\n",
+    "z = 1 / 0  # ZeroDivisionError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"after_error=True\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"final_x={x}\")"
+   ]
+  }
+ ]
+}

--- a/tests/integration_sanity_large.rs
+++ b/tests/integration_sanity_large.rs
@@ -1,0 +1,508 @@
+//! Sanity tests for larger notebooks.
+//!
+//! These tests exercise execution of realistic multi-cell notebooks (20+ cells,
+//! heavy output, error handling, state propagation) in both local mode and
+//! connect mode. They go beyond the small 2–3 cell fixtures used in other tests.
+//!
+//! Local mode (no Jupyter Server required):
+//!   cargo test --test integration_sanity_large -- --test-threads=1
+//!
+//! Connect mode (requires NB_TEST_BACKEND):
+//!   NB_TEST_BACKEND=jsd cargo test --test integration_sanity_large -- --test-threads=1
+//!   NB_TEST_BACKEND=none cargo test --test integration_sanity_large -- --test-threads=1
+
+mod test_helpers;
+
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+use test_helpers::CommandResult;
+
+// ==================== TEST INFRASTRUCTURE ====================
+
+/// Unified test environment that works in both local and connect modes.
+struct SanityEnv {
+    temp_dir: TempDir,
+    binary_path: PathBuf,
+    venv_path_env: String,
+    venv_root: PathBuf,
+}
+
+impl SanityEnv {
+    fn new() -> Option<Self> {
+        let venv_root = test_helpers::setup_execution_venv()?;
+        let venv_path_env = test_helpers::setup_venv_environment()?;
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let binary_path: PathBuf = env!("CARGO_BIN_EXE_nb").into();
+
+        Some(Self {
+            temp_dir,
+            binary_path,
+            venv_path_env,
+            venv_root,
+        })
+    }
+
+    fn copy_fixture(&self, fixture_name: &str, dest_name: &str) -> PathBuf {
+        let dest_path = self.temp_dir.path().join(dest_name);
+        test_helpers::copy_fixture(fixture_name, &dest_path);
+        dest_path
+    }
+
+    /// Run `nb` with the given args from the temp dir.
+    fn run(&self, args: &[&str]) -> CommandResult {
+        let output = Command::new(&self.binary_path)
+            .args(args)
+            .current_dir(self.temp_dir.path())
+            .env("PATH", &self.venv_path_env)
+            .env("VIRTUAL_ENV", &self.venv_root)
+            .env_remove("PYTHONHOME")
+            .output()
+            .expect("Failed to execute nb command");
+
+        CommandResult {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            success: output.status.success(),
+        }
+    }
+}
+
+// ==================== LARGE STATEFUL NOTEBOOK (20 cells) ====================
+
+/// Execute a 20-cell notebook with interleaved code/markdown, class definitions,
+/// loops, and cross-cell state dependencies. Verifies the final sentinel and
+/// all assertion cells pass.
+#[test]
+fn test_large_stateful_notebook_full_execution() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "large_stateful.ipynb");
+
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // Verify key outputs propagated across cells
+    assert!(
+        result.stdout.contains("total=4950"),
+        "Expected 'total=4950' from cell 2\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("keys=10"),
+        "Expected 'keys=10' from cell 5\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("word_count=100"),
+        "Expected 'word_count=100' from cell 6\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("combined=5060"),
+        "Expected 'combined=5060' from cell 8 (state propagation)\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("counter_final=25"),
+        "Expected 'counter_final=25' from cell 11 (class across cells)\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("all_assertions_passed=True"),
+        "Expected 'all_assertions_passed=True' from cell 17\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("NOTEBOOK_COMPLETE"),
+        "Expected final 'NOTEBOOK_COMPLETE' sentinel\nStdout: {}",
+        result.stdout
+    );
+}
+
+/// Execute only a subset of cells (cell-index range) in the large notebook.
+/// Verifies partial execution works correctly.
+#[test]
+fn test_large_stateful_notebook_partial_execution() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "large_stateful_partial.ipynb");
+
+    // Execute only cell 0 (imports)
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap(), "--cell-index", "0"])
+        .assert_success();
+
+    assert!(
+        result.stdout.contains("Python 3"),
+        "Expected Python version output from cell 0\nStdout: {}",
+        result.stdout
+    );
+
+    // Only cell 0 should have @@output (executed); other cells are shown as source only.
+    // Count @@output lines — should be exactly 1 for the single executed cell.
+    let output_count = result
+        .stdout
+        .lines()
+        .filter(|line| line.starts_with("@@output"))
+        .count();
+    assert_eq!(
+        output_count, 1,
+        "Partial execution of cell 0 should produce exactly 1 @@output section, got {}",
+        output_count
+    );
+}
+
+/// Read the large notebook and verify structure is intact.
+#[test]
+fn test_large_stateful_notebook_read() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "large_stateful_read.ipynb");
+
+    let result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("Failed to parse JSON output");
+
+    let cells = parsed["cells"].as_array().expect("Expected cells array");
+    assert_eq!(
+        cells.len(),
+        20,
+        "Expected 20 cells in large notebook, got {}",
+        cells.len()
+    );
+
+    // Count cell types
+    let code_cells = cells.iter().filter(|c| c["cell_type"] == "code").count();
+    let md_cells = cells
+        .iter()
+        .filter(|c| c["cell_type"] == "markdown")
+        .count();
+
+    assert_eq!(code_cells, 15, "Expected 15 code cells");
+    assert_eq!(md_cells, 5, "Expected 5 markdown cells");
+}
+
+// ==================== HEAVY OUTPUT NOTEBOOK ====================
+
+/// Execute a notebook that produces substantial output (100+ lines per cell,
+/// large JSON dumps, formatted tables). Verifies output is not truncated.
+#[test]
+fn test_heavy_output_notebook_full_execution() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_heavy_output.ipynb", "heavy_output.ipynb");
+
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // Verify first cell's 100 output lines aren't truncated
+    assert!(
+        result.stdout.contains("output_line_0000"),
+        "Expected first output line\nStdout (first 500): {}",
+        &result.stdout[..result.stdout.len().min(500)]
+    );
+    assert!(
+        result.stdout.contains("output_line_0099"),
+        "Expected last output line (line 99) — output may be truncated\nStdout (last 500): {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+
+    // Verify JSON data cell
+    assert!(
+        result.stdout.contains("\"id\": 49"),
+        "Expected JSON with 50 items (last id=49)\nStdout contains 'id': {}",
+        result.stdout.contains("\"id\"")
+    );
+
+    // Verify matrix output
+    assert!(
+        result.stdout.contains("row_9:"),
+        "Expected all 10 matrix rows\nStdout: {}",
+        &result.stdout[result.stdout.len().saturating_sub(1000)..]
+    );
+
+    // Final sentinel
+    assert!(
+        result.stdout.contains("HEAVY_OUTPUT_COMPLETE"),
+        "Expected final sentinel\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(200)..]
+    );
+}
+
+/// Verify the heavy output notebook's data cell output is valid JSON.
+#[test]
+fn test_heavy_output_json_integrity() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_heavy_output.ipynb", "heavy_json.ipynb");
+
+    // Execute only cell 1 (the JSON output cell) — but cell 1 uses `json` import
+    // so we need to execute the full notebook for state
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // The JSON data should be parseable somewhere in stdout
+    assert!(
+        result.stdout.contains("data_items=50"),
+        "Expected data_items=50 in summary\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(300)..]
+    );
+}
+
+// ==================== ERROR HANDLING ====================
+
+/// Execute a notebook where cell 2 raises ZeroDivisionError.
+/// Without --allow-errors, execution should fail at the error cell.
+#[test]
+fn test_error_notebook_halts_on_error() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_with_error.ipynb", "error_halt.ipynb");
+
+    let result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_failure();
+
+    // The error should be reported in an @@output section
+    let combined = format!("{}\n{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("ZeroDivisionError"),
+        "Expected ZeroDivisionError in output\nOutput: {}",
+        combined
+    );
+
+    // Cells before the error should have @@output (they executed)
+    assert!(
+        result.stdout.contains("setup_done x=10"),
+        "Cell 0 output should appear\nStdout: {}",
+        result.stdout
+    );
+
+    // Cell after error should NOT have an @@output section with its execution result.
+    // The source text "after_error=True" will appear (as cell source), but NOT in an
+    // @@output block. Check that no @@output appears after the error @@output.
+    let lines: Vec<&str> = result.stdout.lines().collect();
+    let error_output_idx = lines
+        .iter()
+        .position(|l| l.contains("@@output") && l.contains("\"output_type\":\"error\""));
+    assert!(
+        error_output_idx.is_some(),
+        "Expected an error @@output section"
+    );
+
+    // After the error output, no subsequent @@output with stdout should appear
+    let after_error_outputs: Vec<&&str> = lines[error_output_idx.unwrap()..]
+        .iter()
+        .filter(|l| l.contains("@@output") && l.contains("\"output_type\":\"stream\""))
+        .collect();
+    assert!(
+        after_error_outputs.is_empty(),
+        "No stream outputs should appear after the error (cells should not execute)\nFound: {:?}",
+        after_error_outputs
+    );
+}
+
+/// Execute a notebook with errors using --allow-errors flag.
+/// Execution should continue past the error cell.
+#[test]
+fn test_error_notebook_continues_with_allow_errors() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_with_error.ipynb", "error_continue.ipynb");
+
+    // With --allow-errors, the command still exits non-zero (error occurred) but
+    // execution continues past the error cell.
+    let result = env.run(&["execute", nb_path.to_str().unwrap(), "--allow-errors"]);
+
+    // The error traceback should appear in an @@output error section
+    assert!(
+        result.stdout.contains("ZeroDivisionError"),
+        "Error should be reported even with --allow-errors\nStdout: {}",
+        result.stdout
+    );
+
+    // Count total @@output sections — with --allow-errors, cells after the error
+    // should also get @@output sections (they executed)
+    let output_lines: Vec<&str> = result
+        .stdout
+        .lines()
+        .filter(|l| l.starts_with("@@output"))
+        .collect();
+
+    // We expect outputs from: cell 0, cell 1, cell 2 (error), cell 3, cell 4 = 5
+    assert_eq!(
+        output_lines.len(),
+        5,
+        "With --allow-errors, expected 5 @@output sections (all cells execute), got {}\nOutputs: {:?}",
+        output_lines.len(),
+        output_lines
+    );
+
+    // Verify post-error cells executed by checking for their stream output text
+    assert!(
+        result.stdout.contains("after_error=True"),
+        "Cell 3 (after error) should execute with --allow-errors\nStdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("final_x=10"),
+        "Cell 4 should execute and have access to pre-error state\nStdout: {}",
+        result.stdout
+    );
+}
+
+// ==================== READ OPERATIONS ON LARGE NOTEBOOKS ====================
+
+/// Read a large notebook in AI-optimized markdown format and verify all cells appear.
+#[test]
+fn test_read_large_notebook_markdown_format() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "read_md.ipynb");
+
+    let result = env
+        .run(&["read", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    // Should have the notebook header sentinel
+    let header = test_helpers::parse_notebook_header(&result.stdout);
+    assert!(
+        header.is_some(),
+        "Expected @@notebook header in markdown output"
+    );
+
+    // Should have all 15 code cells as @@cell sentinels
+    let cell_sentinels = test_helpers::parse_cells(&result.stdout);
+    assert!(
+        cell_sentinels.len() >= 15,
+        "Expected at least 15 @@cell sentinels (code cells), got {}",
+        cell_sentinels.len()
+    );
+
+    // Markdown content should appear
+    assert!(
+        result.stdout.contains("Large Notebook Sanity Test"),
+        "Expected markdown heading in output"
+    );
+    assert!(
+        result.stdout.contains("Section 1: Computation"),
+        "Expected section heading"
+    );
+}
+
+// ==================== CELL OPERATIONS ON LARGE NOTEBOOKS ====================
+
+/// Add a cell to the large notebook and verify the notebook grows.
+#[test]
+fn test_add_cell_to_large_notebook() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "add_cell.ipynb");
+
+    // Add a new code cell at the end
+    env.run(&[
+        "cell",
+        "add",
+        nb_path.to_str().unwrap(),
+        "--source",
+        "print('added_cell_works=True')",
+    ])
+    .assert_success();
+
+    // Read back and verify 21 cells now
+    let result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("Failed to parse JSON");
+    let cells = parsed["cells"].as_array().unwrap();
+    assert_eq!(cells.len(), 21, "Expected 21 cells after adding one");
+
+    // Execute the full notebook including the new cell
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    assert!(
+        exec_result.stdout.contains("added_cell_works=True"),
+        "New cell should execute\nStdout (tail): {}",
+        &exec_result.stdout[exec_result.stdout.len().saturating_sub(300)..]
+    );
+}
+
+/// Delete a cell from the large notebook and verify execution still works.
+#[test]
+fn test_delete_cell_from_large_notebook() {
+    let Some(env) = SanityEnv::new() else {
+        eprintln!("⚠️  Skipping: execution environment not available");
+        return;
+    };
+
+    let nb_path = env.copy_fixture("large_stateful.ipynb", "delete_cell.ipynb");
+
+    // Delete cell at index 1 (the first markdown cell)
+    env.run(&[
+        "cell",
+        "delete",
+        nb_path.to_str().unwrap(),
+        "--cell-index",
+        "1",
+    ])
+    .assert_success();
+
+    // Read back and verify 19 cells now
+    let result = env
+        .run(&["read", nb_path.to_str().unwrap(), "--json"])
+        .assert_success();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result.stdout).expect("Failed to parse JSON");
+    let cells = parsed["cells"].as_array().unwrap();
+    assert_eq!(cells.len(), 19, "Expected 19 cells after deleting one");
+
+    // Execution should still work (we only deleted a markdown cell)
+    let exec_result = env
+        .run(&["execute", nb_path.to_str().unwrap()])
+        .assert_success();
+
+    assert!(
+        exec_result.stdout.contains("NOTEBOOK_COMPLETE"),
+        "Execution should complete after deleting markdown cell\nStdout (tail): {}",
+        &exec_result.stdout[exec_result.stdout.len().saturating_sub(200)..]
+    );
+}

--- a/tests/integration_sanity_large_connect.rs
+++ b/tests/integration_sanity_large_connect.rs
@@ -1,0 +1,626 @@
+//! Connect-mode sanity tests for larger notebooks.
+//!
+//! These are the connect-mode counterparts to integration_sanity_large.rs.
+//! They spin up a real Jupyter Server and exercise the same large-notebook
+//! scenarios over the connect-mode execution path.
+//!
+//! Like integration_connect_mode, these require NB_TEST_BACKEND to be set and
+//! must run single-threaded:
+//!
+//!   NB_TEST_BACKEND=jsd cargo test --test integration_sanity_large_connect -- --test-threads=1
+//!   NB_TEST_BACKEND=none cargo test --test integration_sanity_large_connect -- --test-threads=1
+//!   NB_TEST_BACKEND=jupyter-collaboration cargo test --test integration_sanity_large_connect -- --test-threads=1
+
+mod test_helpers;
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+// ==================== SERVER INFRASTRUCTURE ====================
+// (Same shared-server pattern as integration_connect_mode.rs)
+
+struct SharedServerInfo {
+    server_url: String,
+    token: String,
+    server_root: PathBuf,
+    binary_path: PathBuf,
+    venv_path_env: String,
+    venv_root: PathBuf,
+}
+
+static SHARED_SERVER: OnceLock<Option<SharedServerInfo>> = OnceLock::new();
+static SERVER_STOP_INFO: OnceLock<Mutex<Option<ServerStopInfo>>> = OnceLock::new();
+static REGISTER_SERVER_STOP: Once = Once::new();
+
+fn shared_server() -> Option<&'static SharedServerInfo> {
+    SHARED_SERVER.get_or_init(start_shared_server).as_ref()
+}
+
+struct ServerStopInfo {
+    jupyter_bin: PathBuf,
+    port: u16,
+    venv_path_env: String,
+    venv_root: PathBuf,
+}
+
+fn server_stop_info() -> &'static Mutex<Option<ServerStopInfo>> {
+    SERVER_STOP_INFO.get_or_init(|| Mutex::new(None))
+}
+
+fn register_server_stop_at_exit(info: ServerStopInfo) {
+    if let Ok(mut stop_info) = server_stop_info().lock() {
+        *stop_info = Some(info);
+    }
+
+    REGISTER_SERVER_STOP.call_once(|| unsafe {
+        extern "C" {
+            fn atexit(cb: extern "C" fn()) -> std::os::raw::c_int;
+        }
+
+        let _ = atexit(stop_shared_server_at_exit);
+    });
+}
+
+extern "C" fn stop_shared_server_at_exit() {
+    let Some(info) = server_stop_info()
+        .lock()
+        .ok()
+        .and_then(|mut info| info.take())
+    else {
+        return;
+    };
+
+    let _ = Command::new(&info.jupyter_bin)
+        .args(["server", "stop", &info.port.to_string(), "-y"])
+        .env("PATH", &info.venv_path_env)
+        .env("VIRTUAL_ENV", &info.venv_root)
+        .env_remove("PYTHONHOME")
+        .status();
+}
+
+fn start_shared_server() -> Option<SharedServerInfo> {
+    let backend = test_helpers::test_backend();
+    if backend.is_empty() {
+        eprintln!(
+            "Skipping connect-mode sanity tests: set NB_TEST_BACKEND=jsd, NB_TEST_BACKEND=jupyter-collaboration, or NB_TEST_BACKEND=none"
+        );
+        return None;
+    }
+
+    let venv_root = test_helpers::setup_execution_venv()?;
+    let venv_path_env = test_helpers::setup_venv_environment()?;
+
+    let venv_bin = if cfg!(windows) {
+        venv_root.join("Scripts")
+    } else {
+        venv_root.join("bin")
+    };
+
+    let packages: &[&str] = match backend.as_str() {
+        "jupyter-collaboration" | "collab" => {
+            &["jupyter_server==2.20.0", "jupyter-collaboration==4.4.1"]
+        }
+        "none" | "plain" => &["jupyter_server==2.20.0"],
+        _ => &["jupyter_server==2.20.0", "jupyter-server-documents==0.2.5"],
+    };
+
+    let mut install_args = vec!["pip", "install", "--python", venv_root.to_str().unwrap()];
+    install_args.extend_from_slice(packages);
+    let install_ok = Command::new("uv")
+        .args(&install_args)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !install_ok {
+        eprintln!(
+            "⚠️  Could not install {:?} into test venv for backend '{}'",
+            packages, backend
+        );
+        return None;
+    }
+
+    let jupyter_bin = venv_bin.join("jupyter");
+    if !jupyter_bin.exists() {
+        eprintln!(
+            "⚠️  jupyter binary not found at {} — skipping connect-mode sanity tests",
+            jupyter_bin.display()
+        );
+        return None;
+    }
+
+    let server_root_tmp: &'static TempDir = Box::leak(Box::new(
+        TempDir::new().expect("Failed to create server root tmpdir"),
+    ));
+    let server_root = server_root_tmp.path().to_path_buf();
+
+    let token = "nbsanity123".to_string();
+
+    let mut cmd = Command::new(&jupyter_bin);
+    cmd.args([
+        "server",
+        "--no-browser",
+        &format!("--ServerApp.token={}", token),
+        &format!("--ServerApp.root_dir={}", server_root.display()),
+    ])
+    .env("PATH", &venv_path_env)
+    .env("VIRTUAL_ENV", &venv_root)
+    .env_remove("PYTHONHOME")
+    .current_dir(&server_root)
+    .stdout(std::process::Stdio::null())
+    .stderr(std::process::Stdio::null());
+
+    let mut child = cmd.spawn().ok()?;
+
+    let (server_url, port) = match wait_for_server_list_entry(
+        &jupyter_bin,
+        &server_root,
+        &token,
+        &venv_path_env,
+        &venv_root,
+        Duration::from_secs(30),
+    ) {
+        Some(server) => server,
+        None => {
+            eprintln!("⚠️  Jupyter Server did not appear in time — skipping");
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+    };
+
+    if !wait_for_server(&server_url, &token, Duration::from_secs(15)) {
+        eprintln!("⚠️  Jupyter Server not healthy — skipping");
+        let _ = Command::new(&jupyter_bin)
+            .args(["server", "stop", &port.to_string(), "-y"])
+            .env("PATH", &venv_path_env)
+            .env("VIRTUAL_ENV", &venv_root)
+            .env_remove("PYTHONHOME")
+            .status();
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    }
+
+    register_server_stop_at_exit(ServerStopInfo {
+        jupyter_bin,
+        port,
+        venv_path_env: venv_path_env.clone(),
+        venv_root: venv_root.clone(),
+    });
+
+    let binary_path = env!("CARGO_BIN_EXE_nb").into();
+
+    Some(SharedServerInfo {
+        server_url,
+        token,
+        server_root,
+        binary_path,
+        venv_path_env,
+        venv_root,
+    })
+}
+
+// ==================== TEST CONTEXT ====================
+
+struct TestCtx {
+    info: &'static SharedServerInfo,
+}
+
+impl TestCtx {
+    fn new() -> Option<Self> {
+        if test_helpers::test_backend().is_empty() {
+            return None;
+        }
+
+        match shared_server() {
+            Some(info) => Some(TestCtx { info }),
+            None => panic!(
+                "connect-mode backend '{}' was requested, but the shared Jupyter server was not available",
+                test_helpers::test_backend()
+            ),
+        }
+    }
+
+    fn copy_fixture(&self, fixture_name: &str, dest_name: &str) -> PathBuf {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(fixture_name);
+        let dest_path = self.info.server_root.join(dest_name);
+        fs::copy(&fixture_path, &dest_path)
+            .unwrap_or_else(|_| panic!("Failed to copy fixture {}", fixture_name));
+        dest_path
+    }
+
+    fn copy_fixture_with_teardown(
+        &self,
+        fixture_name: &str,
+        dest_name: &str,
+    ) -> NotebookSession<'_> {
+        self.copy_fixture(fixture_name, dest_name);
+        NotebookSession {
+            ctx: self,
+            dest_name: dest_name.to_string(),
+        }
+    }
+
+    fn delete_session_for(&self, notebook_name: &str) {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(_) => return,
+        };
+
+        rt.block_on(async {
+            let list_url = format!(
+                "{}/api/sessions?token={}",
+                self.info.server_url, self.info.token
+            );
+            let Ok(resp) = reqwest::get(&list_url).await else {
+                return;
+            };
+            let Ok(sessions) = resp.json::<Vec<serde_json::Value>>().await else {
+                return;
+            };
+
+            let client = reqwest::Client::new();
+            for session in sessions {
+                if session.get("path").and_then(|p| p.as_str()) != Some(notebook_name) {
+                    continue;
+                }
+                let Some(id) = session.get("id").and_then(|i| i.as_str()) else {
+                    continue;
+                };
+                let delete_url = format!(
+                    "{}/api/sessions/{}?token={}",
+                    self.info.server_url, id, self.info.token
+                );
+                let _ = client.delete(&delete_url).send().await;
+            }
+        });
+    }
+
+    fn run(&self, args: &[&str]) -> CommandResult {
+        let mut cmd = Command::new(&self.info.binary_path);
+        cmd.args(args);
+        if args.contains(&"execute") && !args.contains(&"--timeout") {
+            cmd.args(["--timeout", "120"]);
+        }
+        let output = cmd
+            .args([
+                "--server",
+                &self.info.server_url,
+                "--token",
+                &self.info.token,
+            ])
+            .current_dir(&self.info.server_root)
+            .env("PATH", &self.info.venv_path_env)
+            .env("VIRTUAL_ENV", &self.info.venv_root)
+            .env_remove("PYTHONHOME")
+            .output()
+            .expect("Failed to execute nb command");
+
+        CommandResult {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            success: output.status.success(),
+        }
+    }
+}
+
+struct NotebookSession<'a> {
+    ctx: &'a TestCtx,
+    dest_name: String,
+}
+
+impl Drop for NotebookSession<'_> {
+    fn drop(&mut self) {
+        self.ctx.delete_session_for(&self.dest_name);
+    }
+}
+
+struct CommandResult {
+    stdout: String,
+    stderr: String,
+    success: bool,
+}
+
+impl CommandResult {
+    fn assert_success(self) -> Self {
+        if !self.success {
+            panic!(
+                "Command failed:\nStderr: {}\nStdout: {}",
+                self.stderr, self.stdout
+            );
+        }
+        self
+    }
+}
+
+// ==================== SERVER HELPERS ====================
+
+fn wait_for_server_list_entry(
+    jupyter_bin: &std::path::Path,
+    server_root: &std::path::Path,
+    token: &str,
+    venv_path_env: &str,
+    venv_root: &std::path::Path,
+    timeout: Duration,
+) -> Option<(String, u16)> {
+    let deadline = Instant::now() + timeout;
+    let mut interval_ms = 200u64;
+
+    while Instant::now() < deadline {
+        if let Some(server) =
+            find_server_list_entry(jupyter_bin, server_root, token, venv_path_env, venv_root)
+        {
+            return Some(server);
+        }
+        std::thread::sleep(Duration::from_millis(interval_ms));
+        interval_ms = (interval_ms * 2).min(2_000);
+    }
+    None
+}
+
+fn find_server_list_entry(
+    jupyter_bin: &std::path::Path,
+    server_root: &std::path::Path,
+    token: &str,
+    venv_path_env: &str,
+    venv_root: &std::path::Path,
+) -> Option<(String, u16)> {
+    let output = Command::new(jupyter_bin)
+        .args(["server", "list", "--jsonlist"])
+        .env("PATH", venv_path_env)
+        .env("VIRTUAL_ENV", venv_root)
+        .env_remove("PYTHONHOME")
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let servers: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let servers = servers.as_array()?;
+    let expected_root = server_root.to_string_lossy();
+
+    for server in servers {
+        let root_dir = server
+            .get("root_dir")
+            .or_else(|| server.get("notebook_dir"))
+            .and_then(|value| value.as_str());
+        if root_dir != Some(expected_root.as_ref()) {
+            continue;
+        }
+        if server.get("token").and_then(|value| value.as_str()) != Some(token) {
+            continue;
+        }
+        let port = server
+            .get("port")
+            .and_then(|value| value.as_u64())
+            .and_then(|port| u16::try_from(port).ok())?;
+        let url = server.get("url").and_then(|value| value.as_str())?;
+        let server_url = url.trim_end_matches('/').to_string();
+        return Some((server_url, port));
+    }
+    None
+}
+
+fn wait_for_server(server_url: &str, token: &str, timeout: Duration) -> bool {
+    let url = format!("{}/api?token={}", server_url, token);
+    let deadline = Instant::now() + timeout;
+    let mut interval_ms = 200u64;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    while Instant::now() < deadline {
+        let ok = rt.block_on(async {
+            match reqwest::get(&url).await {
+                Ok(resp) => resp.status().is_success(),
+                Err(_) => false,
+            }
+        });
+        if ok {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(interval_ms));
+        interval_ms = (interval_ms * 2).min(2_000);
+    }
+    false
+}
+
+// ==================== CONNECT-MODE SANITY TESTS ====================
+
+/// Execute a 20-cell notebook with interleaved code/markdown, class definitions,
+/// loops, and cross-cell state dependencies over connect mode.
+#[test]
+fn test_connect_large_stateful_notebook_full_execution() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping: connect-mode sanity test (no backend set)");
+        return;
+    };
+
+    let _session = ctx.copy_fixture_with_teardown("large_stateful.ipynb", "sanity_stateful.ipynb");
+
+    let result = ctx
+        .run(&["execute", "sanity_stateful.ipynb"])
+        .assert_success();
+
+    assert!(
+        result.stdout.contains("total=4950"),
+        "Expected 'total=4950'\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+    assert!(
+        result.stdout.contains("combined=5060"),
+        "Expected 'combined=5060' (cross-cell state)\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+    assert!(
+        result.stdout.contains("counter_final=25"),
+        "Expected 'counter_final=25' (class across cells)\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+    assert!(
+        result.stdout.contains("all_assertions_passed=True"),
+        "Expected 'all_assertions_passed=True'\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+    assert!(
+        result.stdout.contains("NOTEBOOK_COMPLETE"),
+        "Expected final sentinel\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(200)..]
+    );
+}
+
+/// Heavy output notebook over connect mode — verifies output is not truncated.
+#[test]
+fn test_connect_heavy_output_notebook() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping: connect-mode sanity test (no backend set)");
+        return;
+    };
+
+    let _session = ctx.copy_fixture_with_teardown("large_heavy_output.ipynb", "sanity_heavy.ipynb");
+
+    let result = ctx.run(&["execute", "sanity_heavy.ipynb"]).assert_success();
+
+    assert!(
+        result.stdout.contains("output_line_0000"),
+        "Expected first output line\nStdout (first 500): {}",
+        &result.stdout[..result.stdout.len().min(500)]
+    );
+    assert!(
+        result.stdout.contains("output_line_0099"),
+        "Expected last output line (99) — output may be truncated"
+    );
+    assert!(
+        result.stdout.contains("HEAVY_OUTPUT_COMPLETE"),
+        "Expected final sentinel\nStdout (tail): {}",
+        &result.stdout[result.stdout.len().saturating_sub(200)..]
+    );
+}
+
+/// Error handling over connect mode — execution should halt at error cell.
+#[test]
+fn test_connect_error_notebook_halts() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping: connect-mode sanity test (no backend set)");
+        return;
+    };
+
+    let _session = ctx.copy_fixture_with_teardown("large_with_error.ipynb", "sanity_error.ipynb");
+
+    let result = ctx.run(&["execute", "sanity_error.ipynb"]);
+
+    assert!(!result.success, "Execution should fail when a cell errors");
+
+    let combined = format!("{}\n{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("ZeroDivisionError"),
+        "Expected ZeroDivisionError\nOutput: {}",
+        &combined[combined.len().saturating_sub(500)..]
+    );
+
+    // Verify no @@output stream sections after the error output
+    let lines: Vec<&str> = result.stdout.lines().collect();
+    let error_output_idx = lines
+        .iter()
+        .position(|l| l.contains("@@output") && l.contains("\"output_type\":\"error\""));
+    assert!(
+        error_output_idx.is_some(),
+        "Expected an error @@output section"
+    );
+
+    let after_error_outputs: Vec<&&str> = lines[error_output_idx.unwrap()..]
+        .iter()
+        .filter(|l| l.contains("@@output") && l.contains("\"output_type\":\"stream\""))
+        .collect();
+    assert!(
+        after_error_outputs.is_empty(),
+        "No stream outputs should appear after the error\nFound: {:?}",
+        after_error_outputs
+    );
+}
+
+/// Error handling with --allow-errors over connect mode.
+#[test]
+fn test_connect_error_notebook_continues_with_allow_errors() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping: connect-mode sanity test (no backend set)");
+        return;
+    };
+
+    let _session =
+        ctx.copy_fixture_with_teardown("large_with_error.ipynb", "sanity_error_continue.ipynb");
+
+    let result = ctx.run(&["execute", "sanity_error_continue.ipynb", "--allow-errors"]);
+
+    assert!(
+        result.stdout.contains("ZeroDivisionError"),
+        "Error should be reported\nStdout: {}",
+        &result.stdout[result.stdout.len().saturating_sub(500)..]
+    );
+
+    // All 5 cells should have @@output sections
+    let output_count = result
+        .stdout
+        .lines()
+        .filter(|l| l.starts_with("@@output"))
+        .count();
+    assert_eq!(
+        output_count, 5,
+        "With --allow-errors, expected 5 @@output sections, got {}",
+        output_count
+    );
+
+    assert!(
+        result.stdout.contains("after_error=True"),
+        "Post-error cells should execute\nStdout: {}",
+        &result.stdout[result.stdout.len().saturating_sub(300)..]
+    );
+}
+
+/// Partial execution (single cell) over connect mode.
+#[test]
+fn test_connect_partial_execution() {
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping: connect-mode sanity test (no backend set)");
+        return;
+    };
+
+    let _session = ctx.copy_fixture_with_teardown("large_stateful.ipynb", "sanity_partial.ipynb");
+
+    let result = ctx
+        .run(&["execute", "sanity_partial.ipynb", "--cell-index", "0"])
+        .assert_success();
+
+    assert!(
+        result.stdout.contains("Python 3"),
+        "Expected Python version from cell 0\nStdout: {}",
+        &result.stdout[..result.stdout.len().min(500)]
+    );
+
+    // Only 1 @@output section for the single executed cell
+    let output_count = result
+        .stdout
+        .lines()
+        .filter(|l| l.starts_with("@@output"))
+        .count();
+    assert_eq!(
+        output_count, 1,
+        "Partial execution should produce exactly 1 @@output, got {}",
+        output_count
+    );
+}


### PR DESCRIPTION
Adds sanity tests exercising realistic multi-cell notebooks beyond the small 2–3 cell fixtures used elsewhere. Both **local-mode** and **connect-mode** variants are included.

## New fixtures

| Fixture | Cells | Purpose |
|---------|-------|---------|
| `large_stateful.ipynb` | 20 | Cross-cell state (classes, loops, assertions), mixed code/markdown |
| `large_heavy_output.ipynb` | 6 | 100+ output lines, large JSON, formatted tables, matrices |
| `large_with_error.ipynb` | 5 | Error mid-stream, tests halt vs continue behavior |

## Local-mode tests (`integration_sanity_large.rs`, 10 tests)

1. `test_large_stateful_notebook_full_execution` — 20-cell execution, state propagation
2. `test_large_stateful_notebook_partial_execution` — single cell with `--cell-index`
3. `test_large_stateful_notebook_read` — structural integrity (20 cells)
4. `test_heavy_output_notebook_full_execution` — 100+ lines output not truncated
5. `test_heavy_output_json_integrity` — large JSON completeness
6. `test_error_notebook_halts_on_error` — execution stops at error cell
7. `test_error_notebook_continues_with_allow_errors` — `--allow-errors` continues past error
8. `test_read_large_notebook_markdown_format` — AI-optimized markdown structure
9. `test_add_cell_to_large_notebook` — mutation + re-execution
10. `test_delete_cell_from_large_notebook` — deletion + re-execution

## Connect-mode tests (`integration_sanity_large_connect.rs`, 5 tests)

Same scenarios over a real Jupyter Server, gated behind `NB_TEST_BACKEND`:

1. `test_connect_large_stateful_notebook_full_execution`
2. `test_connect_heavy_output_notebook`
3. `test_connect_error_notebook_halts`
4. `test_connect_error_notebook_continues_with_allow_errors`
5. `test_connect_partial_execution`

## Run

```bash
just test-sanity                    # local mode (no server needed)
just test-sanity-connect            # connect mode, default backend (none)
just test-sanity-connect jsd        # connect mode, jsd backend
```

Not included in `just test-all` — these are opt-in local sanity checks.