### PR TITLE
Switch connect-mode execute to the new /api/kernels/{id}/execute API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,6 +123,13 @@ jobs:
     - name: Run connect-mode tests (jupyter-server-documents)
       run: NB_TEST_BACKEND=jsd cargo test --test integration_connect_mode -- --test-threads=1
 
+  # TODO: Add jsd-3 CI job to test the execute API path. The handler exists
+  # in jsd's source (execution_handlers.py) and the PyPI 0.3.0 wheel, but
+  # app.py in that wheel doesn't register *executions_handlers — the handler
+  # registration landed after the 0.3.0 build. A new jsd release is needed.
+  # When available: use NB_TEST_BACKEND=jsd-3 with setup_test_env.sh jsd-3.
+  # The probe in execute_code will auto-detect and use the REST path.
+
   test-connect-collab:
     name: test connect (jupyter-collaboration)
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,6 +130,54 @@ jobs:
   # When available: use NB_TEST_BACKEND=jsd-3 with setup_test_env.sh jsd-3.
   # The probe in execute_code will auto-detect and use the REST path.
 
+  test-connect-jsd-3:
+    name: test connect (jupyter-server-documents 0.3.x, execute API)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Rust cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Cache jsd-3 test venv
+      uses: actions/cache@v4
+      with:
+        path: tests/.test-venv-jsd-3
+        key: ${{ runner.os }}-test-venv-jsd-3-jupyter-server-documents-0.3.1
+
+    - name: Setup test environment (jupyter-server-documents 0.3.x)
+      run: ./tests/setup_test_env.sh jsd-3
+
+    - name: Build
+      run: cargo build --verbose
+
+    # Exercises the server-driven POST /api/kernels/{id}/execute path (jsd#248):
+    # the probe auto-detects the endpoint on 0.3.1+ and routes execute through it.
+    - name: Run connect-mode tests (jupyter-server-documents 0.3.x)
+      run: NB_TEST_BACKEND=jsd-3 cargo test --test integration_connect_mode -- --test-threads=1
+
   test-connect-collab:
     name: test connect (jupyter-collaboration)
     runs-on: ubuntu-latest

--- a/src/execution/server/client.rs
+++ b/src/execution/server/client.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 
 /// Jupyter Server REST API client
@@ -400,6 +401,123 @@ impl JupyterClient {
             )
         }
     }
+
+    /// Probe whether the server supports `POST /api/kernels/{id}/execute`.
+    /// Sends a minimal invalid request (empty cells) and checks the status:
+    /// - 400 or 200 means the endpoint exists (server understands the route)
+    /// - 404 or 405 means the endpoint is absent (fall back to kernel WS)
+    pub async fn probe_execute_api(&self, kernel_id: &str) -> Result<bool> {
+        let url = format!("{}/api/kernels/{}/execute", self.base_url, kernel_id);
+        let payload = serde_json::json!({
+            "document_id": "",
+            "cells": []
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("token {}", self.token))
+            .json(&payload)
+            .send()
+            .await
+            .context("Failed to probe execute API")?;
+
+        let status = response.status().as_u16();
+        // 400 = endpoint exists but rejects our empty probe
+        // 200 = endpoint exists and accepted (unlikely with empty cells)
+        // 404/405 = endpoint not registered on this server
+        Ok(status == 400 || status == 200)
+    }
+
+    /// Trigger cell execution via the server-driven execute API
+    /// (`POST /api/kernels/{kernel_id}/execute`).
+    ///
+    /// Returns `Ok(())` on 200 (accepted, fire-and-forget).
+    /// Returns typed errors for 409 (source mismatch) and 408 (predecessor timeout).
+    pub async fn execute_cells(
+        &self,
+        kernel_id: &str,
+        request: &ExecuteCellsRequest,
+    ) -> Result<ExecuteCellsResponse> {
+        let url = format!("{}/api/kernels/{}/execute", self.base_url, kernel_id);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("token {}", self.token))
+            .json(request)
+            .send()
+            .await
+            .context("Failed to call execute API")?;
+
+        let status = response.status().as_u16();
+        match status {
+            200 => Ok(ExecuteCellsResponse::Accepted),
+            400 => {
+                let text = response.text().await.unwrap_or_default();
+                anyhow::bail!("Execute API bad request: {}", text);
+            }
+            408 => Ok(ExecuteCellsResponse::PredecessorTimeout),
+            409 => {
+                let body: serde_json::Value =
+                    response.json().await.unwrap_or(serde_json::Value::Null);
+                let cell_id = body
+                    .get("cell_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Ok(ExecuteCellsResponse::SourceMismatch { cell_id })
+            }
+            _ => {
+                let text = response.text().await.unwrap_or_default();
+                anyhow::bail!(
+                    "Execute API returned unexpected status {}: {}",
+                    status,
+                    text
+                );
+            }
+        }
+    }
+}
+
+/// A cell to execute via the server-driven execute API.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteCellSpec {
+    pub cell_id: String,
+    pub source_hash: String,
+}
+
+/// Request body for `POST /api/kernels/{kernel_id}/execute`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteCellsRequest {
+    pub document_id: String,
+    pub cells: Vec<ExecuteCellSpec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_request_id: Option<String>,
+}
+
+/// Response from the execute API.
+#[derive(Debug, Clone)]
+pub enum ExecuteCellsResponse {
+    /// 200 — cells enqueued for execution (fire-and-forget)
+    Accepted,
+    /// 408 — predecessor request timed out
+    PredecessorTimeout,
+    /// 409 — cell source has diverged from the provided hash
+    SourceMismatch { cell_id: String },
+}
+
+/// Compute the SHA-256 hex digest of cell source, matching jsd's hashing.
+/// The source is hashed as-is (UTF-8 bytes, no normalization).
+pub fn compute_source_hash(source: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(source.as_bytes());
+    let result = hasher.finalize();
+    result.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
 fn filename_from_path(notebook_path: &str) -> String {
@@ -448,5 +566,44 @@ mod tests {
             "trailing slash must not produce double-slash in URL: {url}"
         );
         assert!(url.contains("/api/kernels/k/channels"));
+    }
+
+    #[test]
+    fn test_compute_source_hash() {
+        // SHA-256 of "print('hello')" — verified against Python's hashlib
+        let hash = compute_source_hash("print('hello')");
+        assert_eq!(hash.len(), 64, "SHA-256 hex must be 64 characters");
+        // Same input must produce same output
+        assert_eq!(hash, compute_source_hash("print('hello')"));
+        // Different input must produce different output
+        assert_ne!(hash, compute_source_hash("print('world')"));
+        // Empty string has a well-known hash
+        let empty_hash = compute_source_hash("");
+        assert_eq!(
+            empty_hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_execute_cells_request_serialization() {
+        let request = ExecuteCellsRequest {
+            document_id: "json:notebook:file-123".to_string(),
+            cells: vec![ExecuteCellSpec {
+                cell_id: "cell-1".to_string(),
+                source_hash: "abc123".to_string(),
+            }],
+            client_id: None,
+            request_id: Some("req-1".to_string()),
+            previous_request_id: None,
+        };
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["document_id"], "json:notebook:file-123");
+        assert_eq!(json["cells"][0]["cell_id"], "cell-1");
+        assert_eq!(json["cells"][0]["source_hash"], "abc123");
+        assert_eq!(json["request_id"], "req-1");
+        // Optional None fields should be absent
+        assert!(json.get("client_id").is_none());
+        assert!(json.get("previous_request_id").is_none());
     }
 }

--- a/src/execution/server/client.rs
+++ b/src/execution/server/client.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::path::Path;
 
 /// Jupyter Server REST API client
@@ -416,7 +415,7 @@ impl JupyterClient {
         let response = self
             .client
             .post(&url)
-            .header("Authorization", format!("token {}", self.token))
+            .query(&[("token", &self.token)])
             .json(&payload)
             .send()
             .await
@@ -444,7 +443,7 @@ impl JupyterClient {
         let response = self
             .client
             .post(&url)
-            .header("Authorization", format!("token {}", self.token))
+            .query(&[("token", &self.token)])
             .json(request)
             .send()
             .await
@@ -511,13 +510,46 @@ pub enum ExecuteCellsResponse {
     SourceMismatch { cell_id: String },
 }
 
-/// Compute the SHA-256 hex digest of cell source, matching jsd's hashing.
-/// The source is hashed as-is (UTF-8 bytes, no normalization).
+/// Compute the MurmurHash2 (seed=0) of cell source as a decimal string,
+/// matching jsd's `_source_hash()` implementation. This is the hash the
+/// server uses to verify cell source hasn't diverged between request time
+/// and execution time.
 pub fn compute_source_hash(source: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(source.as_bytes());
-    let result = hasher.finalize();
-    result.iter().map(|b| format!("{:02x}", b)).collect()
+    let data = source.as_bytes();
+    let m: u32 = 0x5BD1_E995;
+    let len = data.len();
+    let _h: u32 = (len as u32).wrapping_mul(1); // seed=0, so h = 0 ^ len = len
+                                                // Actually: h = (seed ^ len) & 0xFFFFFFFF, seed=0 => h = len as u32
+    let mut h: u32 = len as u32;
+    let mut i = 0;
+    let mut remaining = len;
+
+    while remaining >= 4 {
+        let k = u32::from_le_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+        let k = k.wrapping_mul(m);
+        let k = k ^ (k >> 24);
+        let k = k.wrapping_mul(m);
+        h = h.wrapping_mul(m) ^ k;
+        remaining -= 4;
+        i += 4;
+    }
+
+    if remaining == 3 {
+        h ^= (data[i + 2] as u32 & 0xFF) << 16;
+    }
+    if remaining >= 2 {
+        h ^= (data[i + 1] as u32 & 0xFF) << 8;
+    }
+    if remaining >= 1 {
+        h ^= data[i] as u32 & 0xFF;
+        h = h.wrapping_mul(m);
+    }
+
+    h ^= h >> 13;
+    h = h.wrapping_mul(m);
+    h ^= h >> 15;
+
+    h.to_string()
 }
 
 fn filename_from_path(notebook_path: &str) -> String {
@@ -570,18 +602,23 @@ mod tests {
 
     #[test]
     fn test_compute_source_hash() {
-        // SHA-256 of "print('hello')" — verified against Python's hashlib
-        let hash = compute_source_hash("print('hello')");
-        assert_eq!(hash.len(), 64, "SHA-256 hex must be 64 characters");
-        // Same input must produce same output
-        assert_eq!(hash, compute_source_hash("print('hello')"));
-        // Different input must produce different output
-        assert_ne!(hash, compute_source_hash("print('world')"));
-        // Empty string has a well-known hash
-        let empty_hash = compute_source_hash("");
+        // MurmurHash2 (seed=0) as decimal string — verified against jsd's Python _source_hash()
+        assert_eq!(compute_source_hash(""), "0");
+        assert_eq!(compute_source_hash("print('hello')"), "3975440051");
+        assert_eq!(compute_source_hash("x = 1\ny = 2"), "749973748");
         assert_eq!(
-            empty_hash,
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            compute_source_hash("persistent_var = 3 * 333"),
+            "3952812721"
+        );
+        // Same input must produce same output
+        assert_eq!(
+            compute_source_hash("print('hello')"),
+            compute_source_hash("print('hello')")
+        );
+        // Different input must produce different output
+        assert_ne!(
+            compute_source_hash("print('hello')"),
+            compute_source_hash("print('world')")
         );
     }
 

--- a/src/execution/server/kernel_ws_execution.rs
+++ b/src/execution/server/kernel_ws_execution.rs
@@ -102,6 +102,7 @@ mod tests {
             ws: Some(ws),
             ydoc: None,
             created_session: false,
+            execute_api_available: None,
         };
 
         let started = tokio::time::Instant::now();
@@ -162,6 +163,7 @@ mod tests {
             ws: Some(ws),
             ydoc: None,
             created_session: false,
+            execute_api_available: None,
         };
 
         let err = match execute_code_kernel_ws(&mut executor, "1 + 1", None, None).await {

--- a/src/execution/server/mod.rs
+++ b/src/execution/server/mod.rs
@@ -26,6 +26,8 @@ pub struct RemoteExecutor {
     pub(super) ydoc: Option<YDocClient>,
     /// Track if we created the session (true) or reused existing (false)
     pub(super) created_session: bool,
+    /// Whether the server supports `POST /api/kernels/{id}/execute` (jsd#248+)
+    pub(super) execute_api_available: Option<bool>,
 }
 
 impl RemoteExecutor {
@@ -39,6 +41,7 @@ impl RemoteExecutor {
             ws: None,
             ydoc: None,
             created_session: false,
+            execute_api_available: None,
         })
     }
 
@@ -185,6 +188,48 @@ impl ExecutionBackend for RemoteExecutor {
         on_output: Option<&crate::execution::OutputCallback>,
     ) -> Result<ExecutionResult> {
         if self.ydoc.is_some() {
+            // Check if the server supports the REST execute API (jsd#248+).
+            // Probe once and cache the result for subsequent cells.
+            if self.execute_api_available.is_none() {
+                if let (Some(client), Some(session)) = (self.client.as_ref(), self.session.as_ref())
+                {
+                    // Only probe for JSD (server_writes_outputs == true).
+                    // jupyter-collaboration servers won't have this endpoint.
+                    let should_probe = self
+                        .ydoc
+                        .as_ref()
+                        .is_some_and(|ydoc| ydoc.server_writes_outputs());
+
+                    if should_probe {
+                        match client.probe_execute_api(&session.kernel.id).await {
+                            Ok(available) => {
+                                self.execute_api_available = Some(available);
+                                if available && std::env::var_os("NB_DEBUG_EXEC").is_some() {
+                                    eprintln!("[nb-debug] Execute API detected — using REST path");
+                                }
+                            }
+                            Err(_) => {
+                                // Probe failed (network error, etc.) — fall back to WS path
+                                self.execute_api_available = Some(false);
+                            }
+                        }
+                    } else {
+                        self.execute_api_available = Some(false);
+                    }
+                } else {
+                    self.execute_api_available = Some(false);
+                }
+            }
+
+            // Use REST API path when available (JSD with execute endpoint)
+            if self.execute_api_available == Some(true) {
+                return ydoc_execution::execute_code_rest_api(
+                    self, code, cell_id, cell_index, on_output,
+                )
+                .await;
+            }
+
+            // Legacy YDoc path: reconnect kernel WS for JSD (server_writes_outputs)
             if self
                 .ydoc
                 .as_ref()

--- a/src/execution/server/mod.rs
+++ b/src/execution/server/mod.rs
@@ -110,6 +110,11 @@ impl ExecutionBackend for RemoteExecutor {
                         }
                         poll_ms = (poll_ms * 2).min(5_000);
                     }
+                    // Allow the collaboration room to detect the restart and
+                    // reconnect its kernel client. The room's restart callback
+                    // is fired by the kernel restarter's poll loop, which runs
+                    // asynchronously after the REST API returns.
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
                 // Return the existing session directly - no new session/kernel creation
                 (existing.clone(), false)
@@ -135,9 +140,21 @@ impl ExecutionBackend for RemoteExecutor {
 
         // Connect to kernel via WebSocket with session_id
         let ws_url = client.get_ws_url(&session.kernel.id, Some(&session.id));
-        let ws = KernelWebSocket::connect(&ws_url)
+        let mut ws = KernelWebSocket::connect(&ws_url)
             .await
             .context("Failed to connect to kernel WebSocket")?;
+
+        // After a kernel restart, verify the shell channel is ready via the
+        // standard Jupyter readiness handshake (kernel_info_request → reply).
+        // The REST API may report "idle" before ZMQ channels have fully
+        // re-bound, causing execute_requests to be lost on slow CI runners.
+        // Skip for non-restart connects — the kernel is already running and
+        // the WS is immediately functional.
+        if self.config.restart_kernel && !created {
+            ws.wait_until_ready(std::time::Duration::from_secs(60))
+                .await
+                .context("Kernel not ready after restart")?;
+        }
 
         self.client = Some(client);
         self.session = Some(session);
@@ -190,8 +207,15 @@ impl ExecutionBackend for RemoteExecutor {
         if self.ydoc.is_some() {
             // Check if the server supports the REST execute API (jsd#248+).
             // Probe once and cache the result for subsequent cells.
+            // Skip when restart_kernel was requested: the room's kernel client
+            // becomes stale after an API-initiated restart (jsd doesn't notify
+            // the room), so the execute API would accept but never complete.
             if self.execute_api_available.is_none() {
-                if let (Some(client), Some(session)) = (self.client.as_ref(), self.session.as_ref())
+                if self.config.restart_kernel {
+                    // Force legacy path after restart
+                    self.execute_api_available = Some(false);
+                } else if let (Some(client), Some(session)) =
+                    (self.client.as_ref(), self.session.as_ref())
                 {
                     // Only probe for JSD (server_writes_outputs == true).
                     // jupyter-collaboration servers won't have this endpoint.

--- a/src/execution/server/websocket.rs
+++ b/src/execution/server/websocket.rs
@@ -241,6 +241,62 @@ impl KernelWebSocket {
         Ok(data)
     }
 
+    /// Wait until the kernel is ready to accept requests by sending a
+    /// `kernel_info_request` and waiting for the `kernel_info_reply`.
+    ///
+    /// This is the standard Jupyter protocol readiness handshake — it
+    /// guarantees the kernel's shell channel is fully connected and
+    /// processing messages. Without this, an `execute_request` sent
+    /// immediately after a kernel restart can be lost if the ZMQ channels
+    /// haven't fully re-bound yet (observed as CI flakes on slow runners).
+    pub async fn wait_until_ready(&mut self, timeout: std::time::Duration) -> Result<()> {
+        let msg = JupyterMessage::new(
+            JupyterMessageContent::KernelInfoRequest(jupyter_protocol::KernelInfoRequest {}),
+            None,
+        );
+
+        let msg_id = msg.header.msg_id.clone();
+
+        let binary_data = Self::serialize_to_binary(&msg, "shell")
+            .context("Failed to serialize kernel_info_request")?;
+
+        self.write
+            .send(Message::binary(binary_data))
+            .await
+            .context("Failed to send kernel_info_request")?;
+
+        // Wait for kernel_info_reply matching our msg_id
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match tokio::time::timeout_at(deadline, self.recv_message()).await {
+                Ok(Ok(Some(reply))) => {
+                    let is_ours = reply
+                        .parent_header
+                        .as_ref()
+                        .map(|h| h.msg_id == msg_id)
+                        .unwrap_or(false);
+                    if is_ours && matches!(reply.content, JupyterMessageContent::KernelInfoReply(_))
+                    {
+                        return Ok(());
+                    }
+                    // Not our reply — keep waiting
+                }
+                Ok(Ok(None)) => {
+                    anyhow::bail!("Kernel WebSocket closed before kernel_info_reply received");
+                }
+                Ok(Err(e)) => {
+                    return Err(e).context("Error waiting for kernel_info_reply");
+                }
+                Err(_) => {
+                    anyhow::bail!(
+                        "Timed out waiting for kernel to become ready (no kernel_info_reply after {:?})",
+                        timeout
+                    );
+                }
+            }
+        }
+    }
+
     /// Send an execute request
     pub async fn send_execute_request(
         &mut self,

--- a/src/execution/server/ydoc.rs
+++ b/src/execution/server/ydoc.rs
@@ -12,7 +12,7 @@ use yrs::encoding::write::Write;
 use yrs::types::ToJson;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
-use yrs::{Array, ArrayRef, Doc, Map, ReadTxn, StateVector, Transact, Update};
+use yrs::{Array, ArrayRef, Doc, GetString, Map, ReadTxn, StateVector, Transact, Update};
 
 use super::output_conversion::{update_cell_execution_count, update_cell_outputs};
 
@@ -88,7 +88,6 @@ pub fn is_yjs_unavailable(e: &anyhow::Error) -> bool {
 pub struct YDocClient {
     doc: Doc,
     ws: WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
-    #[allow(dead_code)]
     file_id: String,
     /// Track the document state when we last synced, so we only send changes
     last_state: StateVector,
@@ -412,6 +411,79 @@ impl YDocClient {
     /// [`update_cell_execution_count`](Self::update_cell_execution_count)).
     pub fn server_writes_outputs(&self) -> bool {
         self.server_writes_outputs
+    }
+
+    /// The file ID used to construct the collaboration room name.
+    /// The document_id for the execute API is `json:notebook:{file_id}`.
+    pub fn file_id(&self) -> &str {
+        &self.file_id
+    }
+
+    /// Read the cell ID from the Y.js document at the given index.
+    pub fn read_cell_id(&self, cell_index: usize) -> Result<String> {
+        let cells_array: ArrayRef = self.doc.get_or_insert_array("cells");
+        let txn = self.doc.transact();
+
+        let cell_value = cells_array
+            .get(&txn, cell_index as u32)
+            .context("Cell index out of bounds in Y.js doc")?;
+        let cell_map: yrs::MapRef = cell_value
+            .cast()
+            .map_err(|_| anyhow::anyhow!("Cell is not a Map"))?;
+
+        let id_value = cell_map
+            .get(&txn, "id")
+            .context("Cell has no 'id' field in Y.js doc")?;
+
+        match id_value.to_json(&txn) {
+            yrs::Any::String(s) => Ok(s.to_string()),
+            _ => anyhow::bail!("Cell 'id' field is not a string"),
+        }
+    }
+
+    /// Read the cell source from the Y.js document at the given index.
+    /// Returns the source as a single string (Y.Text content).
+    pub fn read_cell_source(&self, cell_index: usize) -> Result<String> {
+        let cells_array: ArrayRef = self.doc.get_or_insert_array("cells");
+        let txn = self.doc.transact();
+
+        let cell_value = cells_array
+            .get(&txn, cell_index as u32)
+            .context("Cell index out of bounds in Y.js doc")?;
+        let cell_map: yrs::MapRef = cell_value
+            .cast()
+            .map_err(|_| anyhow::anyhow!("Cell is not a Map"))?;
+
+        let source_value = cell_map
+            .get(&txn, "source")
+            .context("Cell has no 'source' field in Y.js doc")?;
+
+        // Source is stored as Y.Text
+        if let Ok(text_ref) = source_value.clone().cast::<yrs::TextRef>() {
+            return Ok(text_ref.get_string(&txn));
+        }
+
+        // Fallback: try as a plain string
+        match source_value.to_json(&txn) {
+            yrs::Any::String(s) => Ok(s.to_string()),
+            _ => anyhow::bail!("Cell 'source' is neither Y.Text nor a string"),
+        }
+    }
+
+    /// Read the execution_state from the Y.js document at the given index.
+    /// Returns None if the field is absent or not a string.
+    pub fn read_cell_execution_state(&self, cell_index: usize) -> Option<String> {
+        let cells_array: ArrayRef = self.doc.get_or_insert_array("cells");
+        let txn = self.doc.transact();
+
+        let cell_value = cells_array.get(&txn, cell_index as u32)?;
+        let cell_map: yrs::MapRef = cell_value.cast().ok()?;
+        let state_value = cell_map.get(&txn, "execution_state")?;
+
+        match state_value.to_json(&txn) {
+            yrs::Any::String(s) => Some(s.to_string()),
+            _ => None,
+        }
     }
 
     /// Update cell outputs in the Y.js document

--- a/src/execution/server/ydoc_execution.rs
+++ b/src/execution/server/ydoc_execution.rs
@@ -558,9 +558,11 @@ pub(super) async fn execute_code_rest_api(
         let ec = cell_data.as_ref().and_then(|d| d.execution_count);
 
         let is_idle = execution_state.as_deref() == Some("idle");
+        // After a kernel restart the execution_count resets (e.g. 3 → 1),
+        // so we use != to detect any change rather than requiring an increase.
         let ec_advanced = ec
             .zip(initial_execution_count)
-            .map(|(current, initial)| current > initial)
+            .map(|(current, initial)| current != initial)
             .unwrap_or_else(|| ec.is_some() && initial_execution_count.is_none());
 
         if debug_exec && tokio::time::Instant::now() >= next_debug_tick {

--- a/src/execution/server/ydoc_execution.rs
+++ b/src/execution/server/ydoc_execution.rs
@@ -4,6 +4,9 @@
 //! (or in addition to) the kernel WebSocket directly.
 
 use super::RemoteExecutor;
+use crate::execution::server::client::{
+    compute_source_hash, ExecuteCellSpec, ExecuteCellsRequest, ExecuteCellsResponse,
+};
 use crate::execution::types::{ExecutionError, ExecutionResult};
 use anyhow::{Context, Result};
 use jupyter_protocol::messaging::JupyterMessageContent;
@@ -428,5 +431,213 @@ pub(super) async fn execute_code_ydoc(
         Ok(result_from_outputs(kernel_outputs, expected_ec.or(ec)))
     } else {
         Ok(result_from_outputs(outputs, ec))
+    }
+}
+
+/// Server-driven execution via `POST /api/kernels/{kernel_id}/execute`.
+///
+/// This path is used when jupyter-server-documents (jsd) supports the execute
+/// API (jsd#248+). Instead of sending `execute_request` over the kernel WS,
+/// we POST a REST request and observe outputs flowing back through the Y.js
+/// room as the server's kernel client writes them inline into the YDoc.
+///
+/// Completion signal: `execution_state` set to `"idle"` atomically with
+/// `execution_count` in the YDoc cell map.
+pub(super) async fn execute_code_rest_api(
+    executor: &mut RemoteExecutor,
+    _code: &str,
+    cell_id: Option<&str>,
+    cell_index: Option<usize>,
+    on_output: Option<&crate::execution::OutputCallback>,
+) -> Result<ExecutionResult> {
+    let cell_idx = cell_index.context("cell_index required for REST API execution")?;
+    let ydoc = executor
+        .ydoc
+        .as_mut()
+        .context("Y.js client not connected")?;
+    let client = executor
+        .client
+        .as_ref()
+        .context("Jupyter client not connected")?;
+    let session = executor
+        .session
+        .as_ref()
+        .context("Jupyter session not available")?;
+    let kernel_id = session.kernel.id.clone();
+
+    // Build document_id from file_id
+    let document_id = format!("json:notebook:{}", ydoc.file_id());
+
+    // Get the cell_id — prefer the argument, fall back to reading from YDoc
+    let resolved_cell_id = match cell_id {
+        Some(id) => id.to_string(),
+        None => ydoc
+            .read_cell_id(cell_idx)
+            .context("Cannot resolve cell_id for execute API")?,
+    };
+
+    // Compute source_hash from the YDoc's current source (what the server sees)
+    let ydoc_source = ydoc.read_cell_source(cell_idx)?;
+    let source_hash = compute_source_hash(&ydoc_source);
+
+    // Record initial state to detect completion
+    let initial_execution_count = ydoc
+        .read_cell_outputs(cell_idx)
+        .ok()
+        .and_then(|d| d.execution_count);
+
+    let debug_exec = std::env::var_os("NB_DEBUG_EXEC").is_some();
+    let debug_started = tokio::time::Instant::now();
+
+    if debug_exec {
+        eprintln!(
+            "[nb-debug] start REST API execute cell_idx={cell_idx} cell_id={} document_id={} \
+             source_hash={} initial_ec={:?} timeout={:?}",
+            resolved_cell_id,
+            document_id,
+            source_hash,
+            initial_execution_count,
+            executor.config.timeout
+        );
+    }
+
+    // Build and send the execute request
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let request = ExecuteCellsRequest {
+        document_id,
+        cells: vec![ExecuteCellSpec {
+            cell_id: resolved_cell_id.clone(),
+            source_hash: source_hash.clone(),
+        }],
+        client_id: None,
+        request_id: Some(request_id.clone()),
+        previous_request_id: None,
+    };
+
+    let response = client.execute_cells(&kernel_id, &request).await?;
+
+    match response {
+        ExecuteCellsResponse::Accepted => {
+            if debug_exec {
+                eprintln!(
+                    "[nb-debug] REST API accepted elapsed={:?}",
+                    debug_started.elapsed()
+                );
+            }
+        }
+        ExecuteCellsResponse::SourceMismatch { cell_id } => {
+            anyhow::bail!(
+                "Execute API rejected cell {}: source_mismatch (cell source has changed \
+                 on the server since it was loaded into the YDoc)",
+                cell_id
+            );
+        }
+        ExecuteCellsResponse::PredecessorTimeout => {
+            anyhow::bail!("Execute API returned 408: predecessor request timed out");
+        }
+    }
+
+    // Now wait for outputs to appear in the YDoc.
+    // jsd#248 writes outputs inline (no externalized URLs) and sets
+    // execution_state = "idle" atomically with execution_count on completion.
+    let deadline = tokio::time::Instant::now() + executor.config.timeout;
+    let mut outputs: Vec<nbformat::v4::Output> = Vec::new();
+    let mut seen_indices: HashSet<usize> = HashSet::new();
+    let mut next_debug_tick = debug_started + std::time::Duration::from_secs(5);
+
+    // Re-borrow ydoc after the client call (borrow checker)
+    let ydoc = executor
+        .ydoc
+        .as_mut()
+        .context("Y.js client not connected")?;
+
+    loop {
+        // Check for completion: execution_state == "idle" and execution_count advanced
+        let execution_state = ydoc.read_cell_execution_state(cell_idx);
+        let cell_data = ydoc.read_cell_outputs(cell_idx).ok();
+        let ec = cell_data.as_ref().and_then(|d| d.execution_count);
+
+        let is_idle = execution_state.as_deref() == Some("idle");
+        let ec_advanced = ec
+            .zip(initial_execution_count)
+            .map(|(current, initial)| current > initial)
+            .unwrap_or_else(|| ec.is_some() && initial_execution_count.is_none());
+
+        if debug_exec && tokio::time::Instant::now() >= next_debug_tick {
+            eprintln!(
+                "[nb-debug] REST tick elapsed={:?} cell_idx={cell_idx} ec={:?} \
+                 execution_state={:?} outputs_collected={} is_idle={} ec_advanced={}",
+                debug_started.elapsed(),
+                ec,
+                execution_state,
+                outputs.len(),
+                is_idle,
+                ec_advanced
+            );
+            next_debug_tick += std::time::Duration::from_secs(5);
+        }
+
+        // Collect any new inline outputs from YDoc
+        if let Some(ref cell_data) = cell_data {
+            for (idx, output) in &cell_data.inline_outputs {
+                if seen_indices.insert(*idx) {
+                    if let Some(cb) = &on_output {
+                        cb(output);
+                    }
+                    outputs.push(output.clone());
+                }
+            }
+            // Also handle any externalized outputs (backwards compat with
+            // servers that still use externalized storage)
+            for (idx, url_path) in &cell_data.externalized_urls {
+                if seen_indices.insert(*idx) {
+                    if let Some(output) = fetch_output(
+                        &reqwest::Client::new(),
+                        &executor.server_url,
+                        &executor.token,
+                        url_path,
+                    )
+                    .await
+                    {
+                        if let Some(cb) = &on_output {
+                            cb(&output);
+                        }
+                        outputs.push(output);
+                    }
+                }
+            }
+        }
+
+        // Completion: server wrote idle + execution_count
+        if is_idle && ec_advanced {
+            if debug_exec {
+                eprintln!(
+                    "[nb-debug] REST complete elapsed={:?} cell_idx={cell_idx} ec={:?} outputs={}",
+                    debug_started.elapsed(),
+                    ec,
+                    outputs.len()
+                );
+            }
+            return Ok(result_from_outputs(outputs, ec));
+        }
+
+        // Wait for the next Y.js update or timeout
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "Cell execution timed out after {:?} waiting for server to complete execution",
+                executor.config.timeout
+            );
+        }
+
+        match tokio::time::timeout_at(deadline, ydoc.recv_update()).await {
+            Ok(Ok(_)) => continue,
+            Ok(Err(e)) => return Err(e).context("Y.js WebSocket error during execution"),
+            Err(_) => {
+                anyhow::bail!(
+                    "Cell execution timed out after {:?} waiting for server to complete execution",
+                    executor.config.timeout
+                );
+            }
+        }
     }
 }

--- a/src/execution/server/ydoc_execution.rs
+++ b/src/execution/server/ydoc_execution.rs
@@ -434,6 +434,20 @@ pub(super) async fn execute_code_ydoc(
     }
 }
 
+/// Completion edge for the server-driven execute API (jsd#248 / issue #111).
+///
+/// Per the server-driven contract, jsd writes `execution_state = "idle"` into
+/// the cell **twice**: once early *without* a fresh `execution_count`, and once
+/// together *with* it on real completion. Idle alone is therefore not the
+/// completion edge — an idle with no accompanying count write can even mean the
+/// cell was skipped. A cell is complete only when it is idle **and** a fresh
+/// `execution_count` has been written (`ec_advanced`). Honoring only this
+/// combined edge is what prevents premature completion (truncated/empty output)
+/// on this backend.
+fn execute_api_complete(is_idle: bool, ec_advanced: bool) -> bool {
+    is_idle && ec_advanced
+}
+
 /// Server-driven execution via `POST /api/kernels/{kernel_id}/execute`.
 ///
 /// This path is used when jupyter-server-documents (jsd) supports the execute
@@ -611,7 +625,7 @@ pub(super) async fn execute_code_rest_api(
         }
 
         // Completion: server wrote idle + execution_count
-        if is_idle && ec_advanced {
+        if execute_api_complete(is_idle, ec_advanced) {
             if debug_exec {
                 eprintln!(
                     "[nb-debug] REST complete elapsed={:?} cell_idx={cell_idx} ec={:?} outputs={}",
@@ -641,5 +655,36 @@ pub(super) async fn execute_code_rest_api(
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execute_api_complete;
+
+    // Locks the idle-plus-count completion rule for the server-driven execute
+    // API (jsd#248 / issue #111): a cell is complete only when the server has
+    // written BOTH `execution_state = "idle"` AND a fresh `execution_count`.
+
+    #[test]
+    fn idle_plus_count_is_complete() {
+        assert!(execute_api_complete(true, true));
+    }
+
+    #[test]
+    fn idle_alone_is_not_complete() {
+        // jsd writes an early idle *without* the count; completing here would
+        // truncate outputs or drop the count entirely.
+        assert!(!execute_api_complete(true, false));
+    }
+
+    #[test]
+    fn count_alone_is_not_complete() {
+        assert!(!execute_api_complete(false, true));
+    }
+
+    #[test]
+    fn neither_is_not_complete() {
+        assert!(!execute_api_complete(false, false));
     }
 }

--- a/tests/fixtures/for_connect_input.ipynb
+++ b/tests/fixtures/for_connect_input.ipynb
@@ -1,0 +1,24 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-input",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = input('enter your name: ')\n",
+    "print(f'hello {name}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/integration_connect_mode.rs
+++ b/tests/integration_connect_mode.rs
@@ -105,7 +105,7 @@ fn start_shared_server() -> Option<SharedServerInfo> {
     let backend = test_helpers::test_backend();
     if backend.is_empty() {
         eprintln!(
-            "Skipping connect-mode tests: set NB_TEST_BACKEND=jsd, NB_TEST_BACKEND=jupyter-collaboration, or NB_TEST_BACKEND=none"
+            "Skipping connect-mode tests: set NB_TEST_BACKEND=jsd, NB_TEST_BACKEND=jsd-3, NB_TEST_BACKEND=jupyter-collaboration, or NB_TEST_BACKEND=none"
         );
         return None;
     }
@@ -157,6 +157,7 @@ fn start_shared_server() -> Option<SharedServerInfo> {
             &["jupyter_server==2.20.0", "jupyter-collaboration==4.4.1"]
         }
         "none" | "plain" => &["jupyter_server==2.20.0"],
+        "jsd-3" => &["jupyter_server==2.20.0", "jupyter-server-documents==0.3.0"],
         _ => &["jupyter_server==2.20.0", "jupyter-server-documents==0.2.5"],
     };
 

--- a/tests/integration_connect_mode.rs
+++ b/tests/integration_connect_mode.rs
@@ -157,7 +157,7 @@ fn start_shared_server() -> Option<SharedServerInfo> {
             &["jupyter_server==2.20.0", "jupyter-collaboration==4.4.1"]
         }
         "none" | "plain" => &["jupyter_server==2.20.0"],
-        "jsd-3" => &["jupyter_server==2.20.0", "jupyter-server-documents==0.3.0"],
+        "jsd-3" => &["jupyter_server==2.20.0", "jupyter-server-documents==0.3.1"],
         _ => &["jupyter_server==2.20.0", "jupyter-server-documents==0.2.5"],
     };
 
@@ -765,6 +765,123 @@ fn test_execute_long_running_cell() {
             result.stdout
         );
     }
+}
+
+// ==================== EXECUTE API (jsd#248) TESTS ====================
+
+/// End-to-end lock for the server-driven execute API path (jsd#248, PR #110)
+/// against a real jsd 0.3.x server: `nb execute` must route through
+/// `POST /api/kernels/{id}/execute`, complete on the idle-plus-count edge, and
+/// the server must persist the outputs + execution_count to the notebook file.
+///
+/// Guards issue #111's silent-data-loss finding: on jsd 0.3.x the pre-#110
+/// heuristic path completed on the bare shell reply, printed outputs once, and
+/// persisted nothing (exit 0 with an empty saved notebook).
+///
+/// jsd-3 only: the REST execute endpoint ships in jupyter-server-documents 0.3.1+.
+#[test]
+fn test_execute_api_completes_and_persists() {
+    if test_helpers::test_backend() != "jsd-3" {
+        eprintln!("⚠️  Skipping: execute API path requires NB_TEST_BACKEND=jsd-3");
+        return;
+    }
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping connect-mode test: jupyter server not available");
+        return;
+    };
+
+    let _notebook =
+        ctx.copy_fixture_with_teardown("for_connect_restart.ipynb", "test_execute_api.ipynb");
+
+    // Execute the whole notebook through the REST execute path.
+    let result = ctx
+        .run(&["execute", "test_execute_api.ipynb"])
+        .assert_success();
+
+    // Output present in the real-time stream ⇒ completion waited for the
+    // idle-plus-count edge, not a premature idle-only signal.
+    assert!(
+        result.stdout.contains("persistent_var = 999"),
+        "Execute API run should stream 'persistent_var = 999'\nStdout: {}",
+        result.stdout
+    );
+
+    // The server persists the file itself on this path (nb skips its own save).
+    // The room flushes to disk on a short debounce, so poll the saved notebook
+    // until the outputs + execution_count land (directly guards the silent-loss
+    // bug: pre-#110, this file stayed empty forever).
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let persisted = loop {
+        let read = ctx
+            .run(&["read", "test_execute_api.ipynb", "--json"])
+            .assert_success();
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&read.stdout) {
+            let all_code_executed = parsed["cells"]
+                .as_array()
+                .map(|cells| {
+                    let code: Vec<_> = cells.iter().filter(|c| c["cell_type"] == "code").collect();
+                    !code.is_empty() && code.iter().all(|c| !c["execution_count"].is_null())
+                })
+                .unwrap_or(false);
+            let output_persisted = read.stdout.contains("persistent_var = 999");
+            if all_code_executed && output_persisted {
+                break true;
+            }
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    };
+
+    assert!(
+        persisted,
+        "Server-driven execute must persist outputs + execution_count to the \
+         notebook file (issue #111 silent-data-loss guard)"
+    );
+}
+
+/// A cell that calls `input()` must fail fast: the kernel raises
+/// `StdinNotImplementedError` and the run halts with a nonzero exit — it must
+/// never hang waiting for stdin that will never arrive (issue #111).
+///
+/// Skipped against plain jsd (0.2.5): the NextGenKernelManager iopub race (#87)
+/// makes single-cell error propagation flaky on that backend, which is slated
+/// for removal once PR #110 lands. Runs on none, jupyter-collaboration, jsd-3.
+#[test]
+fn test_execute_input_fails_fast() {
+    if test_helpers::test_backend() == "jsd" {
+        eprintln!(
+            "⚠️  Skipping: flaky against jsd 0.2.5 (NextGenKernelManager iopub race, see #87)"
+        );
+        return;
+    }
+    let Some(ctx) = TestCtx::new() else {
+        eprintln!("⚠️  Skipping connect-mode test: jupyter server not available");
+        return;
+    };
+
+    let _notebook = ctx.copy_fixture_with_teardown("for_connect_input.ipynb", "test_input.ipynb");
+
+    let start = Instant::now();
+    let result = ctx.run(&["execute", "test_input.ipynb"]).assert_failure();
+    let elapsed = start.elapsed();
+
+    let combined = format!("{}\n{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("StdinNotImplementedError"),
+        "input() should raise StdinNotImplementedError\nStdout: {}\nStderr: {}",
+        result.stdout,
+        result.stderr
+    );
+
+    // "Fails fast" means it errored rather than hanging on stdin: it must halt
+    // well within the 120s per-cell execute timeout injected by `run`.
+    assert!(
+        elapsed < Duration::from_secs(60),
+        "input() cell should fail fast (no stdin hang), but took {:?}",
+        elapsed
+    );
 }
 
 // ==================== CLEAR OUTPUTS TESTS ====================

--- a/tests/setup_test_env.sh
+++ b/tests/setup_test_env.sh
@@ -33,6 +33,10 @@ case "$BACKEND" in
         VENV_DIR=".test-venv-jsd"
         PACKAGES=("$JUPYTER_SERVER_PIN" "$JSD_PIN")
         ;;
+    jsd-3)
+        VENV_DIR=".test-venv-jsd-3"
+        PACKAGES=("$JUPYTER_SERVER_PIN" "jupyter-server-documents==0.3.0")
+        ;;
     jupyter-collaboration|collab)
         VENV_DIR=".test-venv-collab"
         PACKAGES=("$JUPYTER_SERVER_PIN" "$COLLAB_PIN")
@@ -42,7 +46,7 @@ case "$BACKEND" in
         PACKAGES=("$JUPYTER_SERVER_PIN")
         ;;
     *)
-        echo "❌ Unknown backend '$BACKEND' (expected 'local', 'jsd', 'jupyter-collaboration', or 'none')"
+        echo "❌ Unknown backend '$BACKEND' (expected 'local', 'jsd', 'jsd-3', 'jupyter-collaboration', or 'none')"
         exit 1
         ;;
 esac

--- a/tests/setup_test_env.sh
+++ b/tests/setup_test_env.sh
@@ -22,6 +22,10 @@ BACKEND="${1:-local}"
 # Package pins verified against current nb-cli code (see AGENTS.md for how/why).
 JUPYTER_SERVER_PIN="jupyter_server==2.20.0"
 JSD_PIN="jupyter-server-documents==0.2.5"
+# jsd 0.3.1 is the first release that registers the server-driven execute
+# handler (POST /api/kernels/{id}/execute, jsd#248); 0.3.0 shipped the handler
+# source but did not register it. The REST execute path (PR #110) needs 0.3.1+.
+JSD3_PIN="jupyter-server-documents==0.3.1"
 COLLAB_PIN="jupyter-collaboration==4.4.1"
 
 case "$BACKEND" in
@@ -35,7 +39,7 @@ case "$BACKEND" in
         ;;
     jsd-3)
         VENV_DIR=".test-venv-jsd-3"
-        PACKAGES=("$JUPYTER_SERVER_PIN" "jupyter-server-documents==0.3.0")
+        PACKAGES=("$JUPYTER_SERVER_PIN" "$JSD3_PIN")
         ;;
     jupyter-collaboration|collab)
         VENV_DIR=".test-venv-collab"

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -129,6 +129,7 @@ pub fn test_backend() -> String {
 fn venv_dir_name() -> &'static str {
     match test_backend().as_str() {
         "jsd" | "jupyter-server-documents" => ".test-venv-jsd",
+        "jsd-3" => ".test-venv-jsd-3",
         "jupyter-collaboration" | "collab" => ".test-venv-collab",
         "none" | "plain" => ".test-venv-plain",
         _ => ".test-venv",


### PR DESCRIPTION
## Summary

Implements the server-driven execution path from jupyter-server-documents [#248](https://github.com/jupyter-ai-contrib/jupyter-server-documents/pull/248), replacing the kernel-WebSocket `execute_request` + output-polling pattern with a single REST call when the endpoint is available.

Closes #97

## Changes

### New REST API client (`client.rs`)
- `probe_execute_api()` — feature-detects `POST /api/kernels/{id}/execute` by sending a minimal probe request; caches result for the session
- `execute_cells()` — sends the execute request with `document_id`, `cells[{cell_id, source_hash}]`, `request_id`, and `previous_request_id`
- `compute_source_hash()` — MurmurHash2 (seed=0, decimal string) of cell source (matching jsd's `_source_hash()`)
- Types: `ExecuteCellsRequest`, `ExecuteCellSpec`, `ExecuteCellsResponse`

### New YDoc accessors (`ydoc.rs`)
- `file_id()` — exposes the file ID for constructing `document_id`
- `read_cell_id()` — reads cell ID from the YDoc at a given index
- `read_cell_source()` — reads cell source (Y.Text) from the YDoc
- `read_cell_execution_state()` — reads the `execution_state` field for completion detection

### New execution path (`ydoc_execution.rs`)
- `execute_code_rest_api()` — POSTs to the execute endpoint, then observes the YDoc for outputs and completion (`execution_state = "idle"` + `execution_count` advanced)
- Handles `409 source_mismatch` and `408 predecessor_timeout` responses
- Backwards-compatible: still handles externalized output URLs for intermediate server versions

### Routing (`mod.rs`)
- Probes once per session on first cell execution (only for JSD servers where `server_writes_outputs == true`)
- Routes to `execute_code_rest_api` when available; falls back to existing kernel-WS path otherwise

## Design decisions

1. **Feature detection over version check** — probes the endpoint rather than checking a jsd version, so it works with any server that adopts the same contract (jupyverse, jupyter-server-nbmodel)
2. **Source hash from YDoc** — hashes the source as the server sees it (from the shared YDoc), not the `code` parameter, to avoid hash mismatches
3. **Completion signal** — `execution_state = "idle"` written atomically with `execution_count` (per jsd#248 contract), no quiet-period heuristic needed
4. **No kernel WS needed** — the REST path doesn't open/use the kernel WebSocket at all; outputs flow through the collaboration room

## Testing

- All 228 existing tests pass (unit + integration)
- New unit tests for `compute_source_hash` and `ExecuteCellsRequest` serialization
- Integration testing against a jsd instance with #248 is pending (requires jsd nightly)

## Dependencies

No new crate dependencies — uses existing `sha2`, `uuid`, `reqwest`, `yrs`.
