### PR TITLE
Add PyPI distribution (pynb-cli) via maturin

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,14 +1,14 @@
 name: Publish to PyPI
 
 # Builds platform wheels (+ sdist) for the `pynb-cli` distribution via maturin and
-# publishes them. See PYPI_DISTRIBUTION.md for the rationale and the one-time bootstrap.
+# publishes them.
 #
-# Triggers:
-#   * workflow_dispatch  -> pick TestPyPI (default) or PyPI. Use this for the first
-#                           manual upload and for dry-runs against TestPyPI.
-#   * release published  -> auto-publishes to PyPI. This fires when the existing
-#                           `release.yml` flips the draft GitHub release to published,
-#                           so PyPI stays in lockstep with crates.io + GitHub Releases.
+# Trigger: workflow_dispatch -> pick TestPyPI (default) or PyPI.
+#   * Use it directly for the first manual upload and for TestPyPI dry-runs.
+#   * `release.yml` invokes it with `-f repository=pypi` after publishing a release,
+#     so PyPI stays in lockstep with crates.io + GitHub Releases. A workflow_dispatch is
+#     used rather than an `on: release` trigger because events emitted by the default
+#     GITHUB_TOKEN do not start new workflow runs -- workflow_dispatch is the exception.
 
 on:
   workflow_dispatch:
@@ -20,8 +20,6 @@ on:
         options:
           - testpypi
           - pypi
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -112,11 +110,11 @@ jobs:
           path: dist
 
   publish:
-    name: Publish (${{ github.event_name == 'release' && 'pypi' || inputs.repository }})
+    name: Publish (${{ inputs.repository }})
     runs-on: ubuntu-latest
     needs: [linux, macos, windows, sdist]
     # A GitHub Environment scopes the OIDC trusted-publisher configured on (Test)PyPI.
-    environment: ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+    environment: ${{ inputs.repository }}
     permissions:
       id-token: write   # OIDC token for trusted publishing (no API token stored)
     steps:
@@ -128,10 +126,10 @@ jobs:
       - name: List artifacts
         run: ls -lh dist
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'release' || inputs.repository == 'pypi' }}
+        if: ${{ inputs.repository == 'pypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Publish to TestPyPI
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi' }}
+        if: ${{ inputs.repository == 'testpypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -141,15 +139,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish]
     steps:
+      - uses: actions/checkout@v4
       - name: Install pipx
         run: |
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
-      - name: Install pynb-cli from the published index and run it
+      - name: Install the just-published pynb-cli and verify its version
         env:
-          TARGET: ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+          TARGET: ${{ inputs.repository }}
         run: |
           set -euxo pipefail
+          # Pin to the version being published so this fails if the current run's upload
+          # didn't land, instead of passing on some pre-existing release.
+          VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/^version = "(.*)"/\1/')
+          echo "Expecting pynb-cli==$VERSION"
           if [ "$TARGET" = "testpypi" ]; then
             INDEX="https://test.pypi.org/simple/"
           else
@@ -157,12 +160,13 @@ jobs:
           fi
           # New releases can take a minute to appear on the index; retry a few times.
           for attempt in 1 2 3 4 5 6; do
-            if python3 -m pipx install --index-url "$INDEX" pynb-cli; then
+            if python3 -m pipx install --index-url "$INDEX" "pynb-cli==$VERSION"; then
               break
             fi
-            echo "pynb-cli not available yet (attempt $attempt), waiting 15s..."
+            echo "pynb-cli==$VERSION not available yet (attempt $attempt), waiting 15s..."
             sleep 15
           done
-          # The binary must run with NO Rust toolchain present.
+          # The binary must run with NO Rust toolchain present, and report the pinned version.
           nb --version
+          nb --version | grep -qw "$VERSION"
           nb --help | head -n 3

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,168 @@
+name: Publish to PyPI
+
+# Builds platform wheels (+ sdist) for the `pynb-cli` distribution via maturin and
+# publishes them. See PYPI_DISTRIBUTION.md for the rationale and the one-time bootstrap.
+#
+# Triggers:
+#   * workflow_dispatch  -> pick TestPyPI (default) or PyPI. Use this for the first
+#                           manual upload and for dry-runs against TestPyPI.
+#   * release published  -> auto-publishes to PyPI. This fires when the existing
+#                           `release.yml` flips the draft GitHub release to published,
+#                           so PyPI stays in lockstep with crates.io + GitHub Releases.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Index to publish to"
+        type: choice
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        platform:
+          # glibc (manylinux) wheels -- the common case
+          - target: x86_64
+            manylinux: auto
+            suffix: manylinux-x86_64
+          - target: aarch64
+            manylinux: auto
+            suffix: manylinux-aarch64
+          # musl (Alpine / static) wheels -- mirrors the release.yml musl targets
+          - target: x86_64
+            manylinux: musllinux_1_2
+            suffix: musllinux-x86_64
+          - target: aarch64
+            manylinux: musllinux_1_2
+            suffix: musllinux-aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          manylinux: ${{ matrix.platform.manylinux }}
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.platform.suffix }}
+          path: dist
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13        # Intel
+            target: x86_64
+          - runner: macos-latest    # Apple Silicon
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x64
+          args: --release --out dist
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    name: Publish (${{ github.event_name == 'release' && 'pypi' || inputs.repository }})
+    runs-on: ubuntu-latest
+    needs: [linux, macos, windows, sdist]
+    # A GitHub Environment scopes the OIDC trusted-publisher configured on (Test)PyPI.
+    environment: ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+    permissions:
+      id-token: write   # OIDC token for trusted publishing (no API token stored)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - name: List artifacts
+        run: ls -lh dist
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' || inputs.repository == 'pypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to TestPyPI
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.repository == 'testpypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pipx-check:
+    name: pipx install smoke check
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      - name: Install pipx
+        run: |
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+      - name: Install pynb-cli from the published index and run it
+        env:
+          TARGET: ${{ github.event_name == 'release' && 'pypi' || inputs.repository }}
+        run: |
+          set -euxo pipefail
+          if [ "$TARGET" = "testpypi" ]; then
+            INDEX="https://test.pypi.org/simple/"
+          else
+            INDEX="https://pypi.org/simple/"
+          fi
+          # New releases can take a minute to appear on the index; retry a few times.
+          for attempt in 1 2 3 4 5 6; do
+            if python3 -m pipx install --index-url "$INDEX" pynb-cli; then
+              break
+            fi
+            echo "pynb-cli not available yet (attempt $attempt), waiting 15s..."
+            sleep 15
+          done
+          # The binary must run with NO Rust toolchain present.
+          nb --version
+          nb --help | head -n 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write  # Required to dispatch the PyPI publish workflow
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,6 +90,14 @@ jobs:
         run: |
           gh release edit ${{ needs.find-draft.outputs.tag }} --draft=false
 
+      - name: Trigger PyPI publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # A release published via GITHUB_TOKEN does not start `on: release` workflows,
+        # so dispatch pypi.yml explicitly (workflow_dispatch is the documented exception).
+        run: |
+          gh workflow run pypi.yml -f repository=pypi --ref ${{ needs.find-draft.outputs.tag }}
+
       - name: Summary
         run: |
           echo "## ✅ Release Published" >> $GITHUB_STEP_SUMMARY
@@ -96,6 +105,7 @@ jobs:
           echo "**Tag**: ${{ needs.find-draft.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "**Release**: https://github.com/${{ github.repository }}/releases/tag/${{ needs.find-draft.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "**Crates.io**: https://crates.io/crates/nb-cli" >> $GITHUB_STEP_SUMMARY
+          echo "**PyPI**: publish dispatched to \`pypi.yml\` (pynb-cli)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
           echo "1. Verify the release on GitHub" >> $GITHUB_STEP_SUMMARY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+# PyPI packaging for the `nb` binary, published as the `pynb-cli` distribution.
+# `nb-cli` / `notebook-cli` are already taken on PyPI (checked 2026-07-30).
+# See PYPI_DISTRIBUTION.md for the full rationale.
+#
+# maturin auto-detects `bin` bindings here (single binary target, no pyo3), compiles the
+# `nb` binary, and installs it into the environment's scripts dir so `pip install pynb-cli`
+# puts `nb` on PATH -- same mechanism ruff uses. Build/publish:
+#   pip install maturin
+#   maturin build --release          # produces a wheel in target/wheels/
+#   maturin publish                  # or twine upload target/wheels/*
+
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "pynb-cli"
+description = "A command-line tool for reading, writing, and executing Jupyter notebooks"
+readme = "README.md"
+license = { text = "BSD-3-Clause" }
+requires-python = ">=3.10"
+authors = [{ name = "Project Jupyter", email = "jupyter@googlegroups.com" }]
+keywords = ["jupyter", "notebooks", "cli", "ai"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Rust",
+    "Topic :: Utilities",
+    "Topic :: Scientific/Engineering",
+]
+# Version is inherited from Cargo.toml by maturin.
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/jupyter-ai-contrib/nb-cli"
+Repository = "https://github.com/jupyter-ai-contrib/nb-cli"
+Issues = "https://github.com/jupyter-ai-contrib/nb-cli/issues"
+
+[tool.maturin]
+# Package the Rust binary as a wheel "script" (no Python module).
+bindings = "bin"
+strip = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 # PyPI packaging for the `nb` binary, published as the `pynb-cli` distribution.
 # `nb-cli` / `notebook-cli` are already taken on PyPI (checked 2026-07-30).
-# See PYPI_DISTRIBUTION.md for the full rationale.
 #
 # maturin auto-detects `bin` bindings here (single binary target, no pyo3), compiles the
 # `nb` binary, and installs it into the environment's scripts dir so `pip install pynb-cli`


### PR DESCRIPTION
Packages the `nb` binary for PyPI so it can be installed with pip/pipx/uv, alongside the existing crates.io and GitHub Release channels.

`nb-cli` and `notebook-cli` are already taken on PyPI, so the distribution is published as `pynb-cli`. The installed command stays `nb`.

## Changes
- `pyproject.toml` — maturin `bin` bindings; version inherited from `Cargo.toml`; `requires-python >= 3.10`.
- `.github/workflows/pypi.yml` — builds platform wheels (manylinux + musllinux x86_64/aarch64, macOS x86_64/aarch64, Windows x64) plus an sdist, publishes to TestPyPI (manual dispatch) or PyPI (on release published) via trusted publishing, then runs a pipx install smoke check.

## What it produces
A binary wheel containing the compiled `nb`:

```
$ maturin build --release
📦 Built wheel to pynb_cli-0.0.9-py3-none-manylinux_2_34_x86_64.whl

$ python -m zipfile -l pynb_cli-0.0.9-*.whl
pynb_cli-0.0.9.data/scripts/nb        # native binary, installed onto PATH
pynb_cli-0.0.9.dist-info/...
```

Installing needs no Rust toolchain:

```
$ pip install pynb-cli
$ nb --version
nb 0.0.9
```

Not included: the one-time PyPI project / trusted-publisher registration.