### PR TITLE
ci: bump actions/checkout v4 -> v5 across workflows

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -57,7 +57,7 @@ jobs:
       run: echo "Skipping ${{ matrix.asset_name }} (not selected)" && exit 0
       shell: bash
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       if: ${{ contains(matrix.enabled_for, inputs.platforms) }}
@@ -107,7 +107,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       tag: ${{ steps.check_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -101,7 +101,7 @@ jobs:
             asset_name: nb-windows-amd64.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.tag }}
 
@@ -166,7 +166,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.create-tag.outputs.tag }}
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -58,7 +58,7 @@ jobs:
             manylinux: musllinux_1_2
             suffix: musllinux-aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Build wheels
@@ -94,7 +94,7 @@ jobs:
           - x86_64
           - aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Build wheels
@@ -111,7 +111,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Build wheels
@@ -128,7 +128,7 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Build sdist
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Install pipx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       tag: ${{ steps.find_draft.outputs.tag }}
       should_publish: ${{ steps.check_published.outputs.should_publish }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Find draft release
         id: find_draft
@@ -59,7 +59,7 @@ jobs:
       id-token: write  # Required for trusted publishing
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.find-draft.outputs.tag }}
 
@@ -80,7 +80,7 @@ jobs:
       contents: write
       actions: write  # Required to dispatch the PyPI publish workflow
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.find-draft.outputs.tag }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: cargo fmt
       run: cargo fmt -- --check
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4
@@ -189,7 +189,7 @@ jobs:
     # so the execute/restart tests this backend actually cares about gate CI.
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4
@@ -235,7 +235,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4
@@ -282,7 +282,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Rust cache
       uses: actions/cache@v4


### PR DESCRIPTION
Bumps `actions/checkout@v4` to `@v5` across all workflows. `checkout@v4` bundles Node.js 20, which runners now flag as deprecated; `@v5` targets Node.js 24 natively and clears the warning.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is kept as a safety net for third-party actions that may still ship Node.js 20.