### PR TITLE
Fix Linux wheel builds and add dry-run to PyPI workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -65,11 +65,11 @@ jobs:
           manylinux: ${{ matrix.platform.manylinux }}
           sccache: "true"
           # Keep native-tls/openssl: the vendored OpenSSL build (openssl-src) needs
-          # perl's IPC::Cmd, which manylinux2014 (yum) lacks and the musllinux/Alpine
-          # image needs perl+make for. Install them before cargo builds openssl.
+          # several perl modules (IPC::Cmd, Time::Piece, ...) that the manylinux2014
+          # (yum) image lacks; the musllinux/Alpine image only needs perl+make.
           before-script-linux: |
             if command -v yum >/dev/null 2>&1; then
-              yum install -y perl-IPC-Cmd perl-Data-Dumper
+              yum install -y perl-core perl-IPC-Cmd perl-Time-Piece perl-Data-Dumper
             elif command -v apk >/dev/null 2>&1; then
               apk add --no-cache perl make
             fi

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,6 +20,14 @@ on:
         options:
           - testpypi
           - pypi
+      dry_run:
+        description: "Build wheels only (skip publishing + install smoke check)"
+        type: boolean
+        default: false
+      ref:
+        description: "Git ref (tag/branch/SHA) to build from. Empty = the ref this run was dispatched on."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -28,6 +36,7 @@ jobs:
   linux:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         platform:
           # glibc (manylinux) wheels -- the common case
@@ -46,6 +55,8 @@ jobs:
             suffix: musllinux-aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -53,6 +64,15 @@ jobs:
           args: --release --out dist
           manylinux: ${{ matrix.platform.manylinux }}
           sccache: "true"
+          # Keep native-tls/openssl: the vendored OpenSSL build (openssl-src) needs
+          # perl's IPC::Cmd, which manylinux2014 (yum) lacks and the musllinux/Alpine
+          # image needs perl+make for. Install them before cargo builds openssl.
+          before-script-linux: |
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y perl-IPC-Cmd perl-Data-Dumper
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache perl make
+            fi
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.suffix }}
@@ -69,6 +89,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -84,6 +106,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -99,6 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
@@ -113,6 +139,7 @@ jobs:
     name: Publish (${{ inputs.repository }})
     runs-on: ubuntu-latest
     needs: [linux, macos, windows, sdist]
+    if: ${{ !inputs.dry_run }}
     # A GitHub Environment scopes the OIDC trusted-publisher configured on (Test)PyPI.
     environment: ${{ inputs.repository }}
     permissions:
@@ -140,6 +167,8 @@ jobs:
     needs: [publish]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install pipx
         run: |
           python3 -m pip install --user pipx

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -44,7 +44,11 @@ jobs:
             manylinux: auto
             suffix: manylinux-x86_64
           - target: aarch64
-            manylinux: auto
+            # manylinux2014 (glibc 2.17) headers predate AT_HWCAP2, so aws-lc-sys
+            # (pulled in by reqwest's rustls default) fails to compile on aarch64.
+            # 2_28 (AlmaLinux 8, glibc 2.28) has the modern headers. x86_64 stays on
+            # 2014 for the widest reach.
+            manylinux: "2_28"
             suffix: manylinux-aarch64
           # musl (Alpine / static) wheels -- mirrors the release.yml musl targets
           - target: x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         # A release published via GITHUB_TOKEN does not start `on: release` workflows,
         # so dispatch pypi.yml explicitly (workflow_dispatch is the documented exception).
         run: |
-          gh workflow run pypi.yml -f repository=pypi --ref ${{ needs.find-draft.outputs.tag }}
+          gh workflow run pypi.yml -f repository=pypi -f ref=${{ needs.find-draft.outputs.tag }} --ref ${{ needs.find-draft.outputs.tag }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
The `Publish to PyPI` workflow fails on all four Linux wheel targets: the vendored OpenSSL build (`openssl-src`, pulled in by `native-tls-vendored`) needs perl's `IPC::Cmd`, which the maturin `manylinux2014` container lacks and the `musllinux`/Alpine container needs perl+make for. The native macOS/Windows builds are unaffected.

This installs those build dependencies via `before-script-linux` (dependencies otherwise unchanged), and adds:
- a `dry_run` input to build wheels without publishing,
- a `ref` input to build a specific tag (release path passes the tag),
- `fail-fast: false` so one Linux target no longer cancels the others.